### PR TITLE
Update amount representation from subunits to decimal

### DIFF
--- a/TAIPs/taip-3.md
+++ b/TAIPs/taip-3.md
@@ -47,7 +47,7 @@ As specified in [TAIP-2] the message body is [JSON-LD]. The following attributes
 * `@context` - REQUIRED the JSON-LD context `https://tap.rsvp/schema/1.0` (provisional)
 * `@type` - REQUIRED the JSON-LD type `https://tap.rsvp/schema/1.0#Transfer` (provisional)
 * `asset` - REQUIRED the [CAIP-19](CAIP-19) identifier of the asset
-* `amountSubunits` - OPTIONAL for NFTs and REQUIRED for fungible tokens. Specified as a string with the full amount in integer in the smallest subunit of a token
+* `amount` - OPTIONAL for NFTs and REQUIRED for fungible tokens. Specified as a string with the full amount as a decimal representation of the token
 * `originator` - OPTIONAL an object representing the originating (aka the sender) party (see [TAIP-6](TAIP-6))
 * `beneficiary` - OPTIONAL an object representing the beneficiary (aka the recipient) party (see [TAIP-6](TAIP-6))
 * `settlementId` - OPTIONAL a [CAIP-220](https://github.com/ChainAgnostic/CAIPs/pull/221/files) identifier of the underlying settlement transaction on a blockchain. For more details see below.
@@ -57,9 +57,9 @@ Many of the attributes are optional and through the process of authorization can
   
 #### Transfer Amounts
 
-The amount of a transfer is specified as `amountSubunits` as it is the most precise representation of an amount and is, in most cases, the same as used in the underlying blockchain protocol. For many application developers, this can be error-prone. It is the responsibility of library and tool developers to help educate and help convert between commonly used decimal amounts and the underlying sub-unit.
+The amount of a transfer is specified as `amount` and represents the decimal value of the asset. This approach is more intuitive for most users and application developers. It is the responsibility of library and tool developers to handle any necessary conversions when interacting with blockchain protocols that may require amounts in their smallest units.
 
-As an example `ETH 1.23` should be encoded as `1230000000000000000`.
+As an example, `ETH 1.23` should be encoded as `"1.23"`.
 
 #### `settlementId`
 
@@ -114,7 +114,7 @@ The following is a minimal request for a transfer of 1.23 ETH from a trading fir
     "originator":{
       "@id":"did:web:originator.sample"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents":[
       {
         "@id":"did:web:originator.sample"
@@ -143,7 +143,7 @@ The following is a request for a transfer of 1.23 ETH from a crypto exchange fro
     "originator":{
       "@id":"did:eg:bob"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents":[
       {
         "@id":"did:web:originator.vasp"
@@ -175,7 +175,7 @@ The following is a request for a transfer of 1.23 ETH from a crypto exchange fro
     "beneficiary":{
       "@id":"sms:+15105550101"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents":[
       {
         "@id":"did:web:originator.vasp"
@@ -206,7 +206,7 @@ The following is an example of a reasonably complete transaction already settled
       "@id":"did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {

--- a/TAIPs/taip-5.md
+++ b/TAIPs/taip-5.md
@@ -54,7 +54,7 @@ The following example shows its use in a [TAIP-3] message:
     "originator":{
       "@id":"did:web:originator.sample"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents":[
       {
         "@id":"did:web:originator.sample"
@@ -295,7 +295,7 @@ See the following [TAIP-3] message outlining a typical Asset Transfer where a cu
       "@id":"did:eg:bob",
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {
@@ -331,7 +331,7 @@ After completing the discovery aspects  of TAP the Asset Transfer could look lik
       "@id":"did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {
@@ -381,7 +381,7 @@ After completing the discovery aspects of TAP we discover the Asset Transfer goe
       "@id":"did:eg:bob",
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {

--- a/TAIPs/taip-6.md
+++ b/TAIPs/taip-6.md
@@ -128,7 +128,7 @@ See the following [TAIP-3] message outlining a typical Asset Transfer where a cu
       "@id":"did:eg:bob",
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {
@@ -164,7 +164,7 @@ After completing the discovery aspects of TAP, the Asset Transfer could look lik
       "@id":"did:eg:alice",
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {
@@ -210,7 +210,7 @@ After completing the discovery aspects of TAP, we discover the Asset Transfer go
       "@id":"did:eg:bob",
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {

--- a/TAIPs/taip-9.md
+++ b/TAIPs/taip-9.md
@@ -51,7 +51,7 @@ As an example see the following [TAIP-3] object:
       "@id":"did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId":"eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents":[
       {


### PR DESCRIPTION
- Replace 'amountSubunits' with 'amount' in all TAIPs
- Change amount representation from smallest units to decimal values
- Update examples to use decimal amounts (e.g., 1.23 instead of 1230000000000000000)
- Adjust descriptions to reflect the new decimal representation