### PR TITLE
Rename TAIP-18 Exchange message type to RFQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ This changelog focuses on:
 - Protocol structural changes
 - Breaking changes
 
+## [2026-05-01]
+
+### Changed
+- **TAIP-18 Asset Exchange**: Renamed `Exchange` message type to `RFQ` (Request for Quote) based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
+  - Message type identifier `https://tap.rsvp/schema/1.0#Exchange` is now `https://tap.rsvp/schema/1.0#RFQ`
+  - JSON-LD `@type` value changed from `Exchange` to `RFQ`
+  - Schema file renamed from `schemas/messages/exchange.json` to `schemas/messages/rfq.json`
+  - TypeScript: `Exchange`/`ExchangeMessage` types renamed to `RFQ`/`RFQMessage`; validators and arbitraries renamed accordingly
+  - TAIP-14 references to `Exchange/Quote` flow updated to `RFQ/Quote`
+  - "Asset Exchange" remains the title and conceptual name of the protocol; only the specific message identifier changed
+
 ## [2026-03-17]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog focuses on:
 ## [2026-05-01]
 
 ### Changed
+- **TAIP-18 Asset Exchange**: Status advanced from Draft to Review
 - **TAIP-18 Asset Exchange**: Renamed `Exchange` message type to `RFQ` (Request for Quote) based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
   - Message type identifier `https://tap.rsvp/schema/1.0#Exchange` is now `https://tap.rsvp/schema/1.0#RFQ`
   - JSON-LD `@type` value changed from `Exchange` to `RFQ`

--- a/TAIPs/taip-14.md
+++ b/TAIPs/taip-14.md
@@ -5,7 +5,7 @@ status: Review
 type: Standard
 author: Pelle Braendgaard <pelle@notabene.id>
 created: 2024-03-21
-updated: 2025-09-05
+updated: 2026-05-01
 description: Defines a merchant-initiated Payment message standard for requesting blockchain payments with specified amounts in either crypto assets or fiat currencies. Enables selective disclosure of customer information for compliance and business purposes while facilitating standard e-commerce and invoice payment flows with privacy protection.
 requires: 2, 3, 4, 6, 7, 8, 9, 16, 18
 ---
@@ -38,7 +38,7 @@ A **Payment** is a [DIDComm] message (per [TAIP-2]) initiated by the merchant's 
 - **`asset`** – *Optional*, **string** ([CAIP-19] or [DTI] identifier) for the specific cryptocurrency being requested. Must be a blockchain asset identifier. Either `asset` OR `currency` is required (one must be present); if both are given, they should be consistent, with `asset` having precedence (the wallet should send in the asset specified, not based on currency).
 - **`currency`** – *Optional*, **string** (ISO 4217 currency code, e.g. "USD" or "EUR") for fiat-denominated payments. Either `asset` OR `currency` is required (one must be present). If `currency` is present, a wallet might not know which crypto asset the merchant prefers to settle this fiat amount; this is addressed by the `supportedAssets` field.
 - **`supportedAssets`** – *Optional*, **array of strings or objects** ([CAIP-19] or [DTI] asset identifiers, or pricing objects). If `currency` is given (fiat-denominated request), this field can list which crypto assets are acceptable to settle that currency amount. Each entry can be either:
-  - **String format**: A simple asset identifier (e.g., `"eip155:1/erc20:0xA0b86991..."`) for assets with ~1:1 exchange rates like stablecoins. Additional price negotiation may be needed offline or via Exchange/Quote messages from [TAIP-18].
+  - **String format**: A simple asset identifier (e.g., `"eip155:1/erc20:0xA0b86991..."`) for assets with ~1:1 exchange rates like stablecoins. Additional price negotiation may be needed offline or via RFQ/Quote messages from [TAIP-18].
   - **Object format**: A pricing object with `asset` (required [CAIP-19], [DTI] identifier, or [ISO-4217] currency code), `amount` (required string decimal representing how much of this asset or currency is needed), and optional `expires` (ISO 8601 timestamp when this exchange rate expires). For example: `{"asset": "eip155:1:0x...", "amount": "0.0004", "expires": "2025-07-30T15:00:00Z"}` indicates 0.0004 of the specified crypto asset is needed, or `{"asset": "EUR", "amount": "230.50", "expires": "2025-07-30T15:00:00Z"}` indicates €230.50 is needed to settle a USD invoice, with this rate valid until the expiration time.
   
   If `supportedAssets` is omitted for a fiat request, it implies the customer's wallet may choose any asset to settle that amount, subject to the merchant and wallet's out-of-band agreement or policy. When using object format, if `expires` is omitted, the rate follows the Payment's overall `expiry` timestamp.
@@ -216,7 +216,7 @@ The **AuthorizationRequired** message includes an `authorizationUrl` field point
 
 ### Composability
 
-Most simple payments involving a single blockchain and a single token transfer can be implemented using the `Payment` -> `Authorize` -> `Authorize` -> `Settle` flow. More complex payments may require asset conversion between different stablecoins or currencies. These scenarios can be handled using `Exchange` and `Quote` messages from [TAIP-18], with the Exchange referring to the parent Payment through the `pthid` field (see [TAIP-2]).
+Most simple payments involving a single blockchain and a single token transfer can be implemented using the `Payment` -> `Authorize` -> `Authorize` -> `Settle` flow. More complex payments may require asset conversion between different stablecoins or currencies. These scenarios can be handled using `RFQ` and `Quote` messages from [TAIP-18], with the RFQ referring to the parent Payment through the `pthid` field (see [TAIP-2]).
 
 ```mermaid
 sequenceDiagram
@@ -228,7 +228,7 @@ sequenceDiagram
     PSP->>CustomerWallet: Payment (USDT, 1000.00)
     Note over CustomerWallet: Customer only has EURC
     
-    CustomerWallet->>LiquidityProvider: Exchange (EURC → USDT, pthid: payment-id)
+    CustomerWallet->>LiquidityProvider: RFQ (EURC → USDT, pthid: payment-id)
     LiquidityProvider-->>CustomerWallet: Quote (908.50 EURC → 1000.00 USDT)
     
     CustomerWallet-->>LiquidityProvider: Authorize (accept quote)

--- a/TAIPs/taip-18.md
+++ b/TAIPs/taip-18.md
@@ -1,7 +1,7 @@
 ---
 taip: 18
 title: Asset Exchange
-status: Draft
+status: Review
 type: Standard
 author: Tarek Mohammad <tarek.mohammad@notabene.id>, Pelle Braendgaard <pelle@notabene.id>
 created: 2025-07-20

--- a/TAIPs/taip-18.md
+++ b/TAIPs/taip-18.md
@@ -5,8 +5,8 @@ status: Draft
 type: Standard
 author: Tarek Mohammad <tarek.mohammad@notabene.id>, Pelle Braendgaard <pelle@notabene.id>
 created: 2025-07-20
-updated: 2025-08-23
-description: Defines Exchange and Quote message types for requesting and executing token swaps and price quotations. Enables cross-asset quotes, swap route approval, and settlement with minimal trust assumptions while maintaining composability with existing TAP messages.
+updated: 2026-05-01
+description: Defines RFQ and Quote message types for requesting and executing token swaps and price quotations. Enables cross-asset quotes, swap route approval, and settlement with minimal trust assumptions while maintaining composability with existing TAP messages.
 requires: 2, 3, 4, 5, 6, 7, 8, 9, 14, 17
 ---
 
@@ -18,7 +18,7 @@ A standard for requesting and executing asset exchanges and price quotations for
 
 ## Abstract
 
-TAIP-18 introduces an Exchange message format for initiating cross-asset quotes (e.g., from USDC to EURC, USD to USDC, or across chains) and defines optional settlement support for accepted quotes. It is designed for composability with existing TAP messages like Payment ([TAIP-14]) and Transfer ([TAIP-3]). TAIP-18 formalizes the message exchange required to:
+TAIP-18 introduces an RFQ (Request for Quote) message format for initiating cross-asset quotes (e.g., from USDC to EURC, USD to USDC, or across chains) and defines optional settlement support for accepted quotes. It is designed for composability with existing TAP messages like Payment ([TAIP-14]) and Transfer ([TAIP-3]). TAIP-18 formalizes the message exchange required to:
 
 * Quote and approve stablecoin swaps
 * Discover on-/off-ramp pricing
@@ -41,21 +41,21 @@ TAIP-18 solves this by creating a compliant, composable quote & swap framework t
 
 ## Specification
 
-TAIP-18 defines two new message types for quote negotiation (`Exchange` and `Quote`) and reuses existing [TAIP-4] messages (`Authorize` and `Settle`) for quote acceptance and swap settlement:
+TAIP-18 defines two new message types for quote negotiation (`RFQ` and `Quote`) and reuses existing [TAIP-4] messages (`Authorize` and `Settle`) for quote acceptance and swap settlement:
 
-### 1. `Exchange`
+### 1. `RFQ`
 
-An **Exchange** is a [DIDComm] message (per [TAIP-2]) sent by the party initiating an exchange request. Like all TAP messages, it follows the DIDComm v2 message structure with the TAP-specific body format.
+An **RFQ** (Request for Quote) is a [DIDComm] message (per [TAIP-2]) sent by the party initiating a quote request. Like all TAP messages, it follows the DIDComm v2 message structure with the TAP-specific body format.
 
-The exchange request identifies the parties involved in the potential transaction and the agents acting on their behalf. The `requester` party represents the entity seeking the exchange. The optional `provider` party represents a specific liquidity provider being engaged; when omitted, the Exchange message can be broadcast through a centralized service or sent to multiple providers who can each choose to respond with a Quote. The `agents` array lists all software agents involved in processing this exchange request, including their roles and the parties they represent.
+The RFQ identifies the parties involved in the potential transaction and the agents acting on their behalf. The `requester` party represents the entity seeking the exchange. The optional `provider` party represents a specific liquidity provider being engaged; when omitted, the RFQ message can be broadcast through a centralized service or sent to multiple providers who can each choose to respond with a Quote. The `agents` array lists all software agents involved in processing this RFQ, including their roles and the parties they represent.
 
-The Exchange message supports multiple assets in both `fromAssets` and `toAssets` arrays, enabling complex exchange scenarios. For example, when responding to a Payment request ([TAIP-14]) that lists multiple EUR stablecoins as supportedAssets, but the customer only has USD stablecoins available, they can list their available USD tokens in `fromAssets` and the merchant's supported EUR tokens in `toAssets`, allowing providers to quote cross-currency exchanges.
+The RFQ message supports multiple assets in both `fromAssets` and `toAssets` arrays, enabling complex exchange scenarios. For example, when responding to a Payment request ([TAIP-14]) that lists multiple EUR stablecoins as supportedAssets, but the customer only has USD stablecoins available, they can list their available USD tokens in `fromAssets` and the merchant's supported EUR tokens in `toAssets`, allowing providers to quote cross-currency exchanges.
 
 The DIDComm message envelope contains:
 
 - **`from`** – REQUIRED [DID] of the initiating agent
 - **`to`** – REQUIRED Array containing [DID] of the liquidity providers or orchestrators
-- **`type`** – REQUIRED Message type: `"https://tap.rsvp/schema/1.0#Exchange"`
+- **`type`** – REQUIRED Message type: `"https://tap.rsvp/schema/1.0#RFQ"`
 - **`id`** – REQUIRED Unique message identifier
 - **`thid`** – OPTIONAL Thread identifier for related messages (e.g., a Payment from [TAIP-14])
 - **`created_time`** – REQUIRED Message creation timestamp
@@ -64,21 +64,21 @@ The DIDComm message envelope contains:
 The message `body` contains:
 
 - **`@context`** – REQUIRED JSON-LD context: `"https://tap.rsvp/schema/1.0"`
-- **`@type`** – REQUIRED Type identifier: `"https://tap.rsvp/schema/1.0#Exchange"`
+- **`@type`** – REQUIRED Type identifier: `"https://tap.rsvp/schema/1.0#RFQ"`
 - **`fromAssets`** – REQUIRED Array of [CAIP-19], DTI, or [ISO-4217] currency codes for available source assets
 - **`toAssets`** – REQUIRED Array of [CAIP-19], DTI, or [ISO-4217] currency codes for desired target assets
 - **`fromAmount`** – CONDITIONAL Amount of source asset to exchange (string decimal). Either `fromAmount` or `toAmount` must be provided
 - **`toAmount`** – CONDITIONAL Amount of target asset desired (string decimal). Either `fromAmount` or `toAmount` must be provided
 - **`requester`** – REQUIRED The party requesting the exchange (Party object per [TAIP-6])
-- **`provider`** – OPTIONAL The preferred liquidity provider party (Party object per [TAIP-6]). When omitted, the Exchange message can be broadcast to multiple providers
-- **`agents`** – REQUIRED Array of agents involved in the exchange request per [TAIP-5]
+- **`provider`** – OPTIONAL The preferred liquidity provider party (Party object per [TAIP-6]). When omitted, the RFQ message can be broadcast to multiple providers
+- **`agents`** – REQUIRED Array of agents involved in the RFQ per [TAIP-5]
 - **`policies`** – OPTIONAL Compliance or presentation requirements per [TAIP-7]
 
 ### 2. `Quote`
 
-A **Quote** is a [DIDComm] message sent by the liquidity provider or orchestrator in response to an Exchange request.
+A **Quote** is a [DIDComm] message sent by the liquidity provider or orchestrator in response to an RFQ.
 
-The quote response includes the `provider` party information and an updated `agents` array. The agents array must contain all agents from the original Exchange request plus any additional agents representing the provider. This ensures full traceability of all parties and agents involved in the potential transaction.
+The quote response includes the `provider` party information and an updated `agents` array. The agents array must contain all agents from the original RFQ plus any additional agents representing the provider. This ensures full traceability of all parties and agents involved in the potential transaction.
 
 The DIDComm message envelope contains:
 
@@ -86,7 +86,7 @@ The DIDComm message envelope contains:
 - **`to`** – REQUIRED Array containing [DID] of the original requester
 - **`type`** – REQUIRED Message type: `"https://tap.rsvp/schema/1.0#Quote"`
 - **`id`** – REQUIRED Unique message identifier
-- **`thid`** – REQUIRED Thread identifier linking to the original Exchange request
+- **`thid`** – REQUIRED Thread identifier linking to the original RFQ
 - **`created_time`** – REQUIRED Message creation timestamp
 
 The message `body` contains:
@@ -98,7 +98,7 @@ The message `body` contains:
 - **`fromAmount`** – REQUIRED Amount of source asset to be exchanged (string decimal)
 - **`toAmount`** – REQUIRED Amount of target asset to be received (string decimal)
 - **`provider`** – REQUIRED The liquidity provider party (Party object per [TAIP-6])
-- **`agents`** – REQUIRED Array of agents involved in the quote per [TAIP-5]. Must include all agents from the original Exchange request plus any provider agents
+- **`agents`** – REQUIRED Array of agents involved in the quote per [TAIP-5]. Must include all agents from the original RFQ plus any provider agents
 - **`expires`** – REQUIRED ISO 8601 timestamp when quote expires
 
 ### 3. Authorization and Settlement
@@ -125,21 +125,21 @@ When the swap is executed, the liquidity provider sends a `Settle` message (per 
 
 ## Example Messages
 
-### Exchange Example
+### RFQ Example
 
 This example shows a complete DIDComm message requesting an exchange from USDC to EURC:
 
 ```json
 {
-  "id": "exchange-request-123",
-  "type": "https://tap.rsvp/schema/1.0#Exchange",
+  "id": "rfq-123",
+  "type": "https://tap.rsvp/schema/1.0#RFQ",
   "from": "did:web:wallet.example",
   "to": ["did:web:lp.example", "did:web:lp2.example"],
   "created_time": 1719226800,
   "expires_time": 1719313200,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Exchange",
+    "@type": "https://tap.rsvp/schema/1.0#RFQ",
     "fromAssets": ["eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
     "toAssets": ["eip155:1/erc20:0xB00b00b00b00b00b00b00b00b00b00b00b00b00b"],
     "fromAmount": "1000.00",
@@ -173,7 +173,7 @@ This example shows a complete DIDComm message requesting an exchange from USDC t
   "type": "https://tap.rsvp/schema/1.0#Quote",
   "from": "did:web:lp.example",
   "to": ["did:web:wallet.example"],
-  "thid": "exchange-request-123",
+  "thid": "rfq-123",
   "created_time": 1719226850,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
@@ -248,18 +248,18 @@ This example shows swap settlement using the standard `Settle` message from [TAI
 
 ### Example: Fiat to Crypto Quote
 
-This example shows an exchange request from USD fiat to USDC stablecoin:
+This example shows an RFQ from USD fiat to USDC stablecoin:
 
 ```json
 {
-  "id": "fiat-exchange-request-111",
-  "type": "https://tap.rsvp/schema/1.0#Exchange",
+  "id": "fiat-rfq-111",
+  "type": "https://tap.rsvp/schema/1.0#RFQ",
   "from": "did:web:user.wallet",
   "to": ["did:web:onramp.provider"],
   "created_time": 1719230000,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Exchange",
+    "@type": "https://tap.rsvp/schema/1.0#RFQ",
     "fromAssets": ["USD"],
     "toAssets": ["eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
     "fromAmount": "1000.00",
@@ -293,7 +293,7 @@ Response:
   "type": "https://tap.rsvp/schema/1.0#Quote",
   "from": "did:web:onramp.provider",
   "to": ["did:web:user.wallet"],
-  "thid": "fiat-exchange-request-111",
+  "thid": "fiat-rfq-111",
   "created_time": 1719230050,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
@@ -322,20 +322,20 @@ Response:
 }
 ```
 
-### Example: Broadcast Exchange Request
+### Example: Broadcast RFQ
 
-This example shows an Exchange request broadcast to multiple providers without specifying a particular provider. The requester has USDC and USDT on Ethereum mainnet available and wants to exchange for either USDC or USDT on Polygon:
+This example shows an RFQ broadcast to multiple providers without specifying a particular provider. The requester has USDC and USDT on Ethereum mainnet available and wants to exchange for either USDC or USDT on Polygon:
 
 ```json
 {
-  "id": "broadcast-exchange-456",
-  "type": "https://tap.rsvp/schema/1.0#Exchange",
+  "id": "broadcast-rfq-456",
+  "type": "https://tap.rsvp/schema/1.0#RFQ",
   "from": "did:web:wallet.example",
   "to": ["did:web:exchange.platform", "did:web:lp1.example", "did:web:lp2.example"],
   "created_time": 1719228000,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Exchange",
+    "@type": "https://tap.rsvp/schema/1.0#RFQ",
     "fromAssets": [
       "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7"
@@ -409,18 +409,18 @@ Note how the Escrow message:
 
 ### Example: Cross-Currency FX Quote
 
-This example shows a pure FX exchange request between fiat currencies:
+This example shows a pure FX RFQ between fiat currencies:
 
 ```json
 {
-  "id": "fx-exchange-request-333",
-  "type": "https://tap.rsvp/schema/1.0#Exchange",
+  "id": "fx-rfq-333",
+  "type": "https://tap.rsvp/schema/1.0#RFQ",
   "from": "did:web:bank.example",
   "to": ["did:web:fx.provider"],
   "created_time": 1719231000,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Exchange",
+    "@type": "https://tap.rsvp/schema/1.0#RFQ",
     "fromAssets": ["USD"],
     "toAssets": ["EUR"],
     "fromAmount": "1000.00",
@@ -454,7 +454,7 @@ The following state diagram shows the possible states and transitions for an exc
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Requested : Exchange
+    [*] --> Requested : RFQ
     Requested --> Quoted : Quote received
     Quoted --> Authorized : Authorize sent
     Authorized --> EscrowRequested : Escrow received (optional)
@@ -480,7 +480,7 @@ sequenceDiagram
     participant Provider as Provider Agent
     participant Blockchain
 
-    Requester->>Provider: Exchange (USDC → EURC)
+    Requester->>Provider: RFQ (USDC → EURC)
     Provider->>Requester: Quote (rates & amounts)
     Note over Requester: User reviews quote
     Requester->>Provider: Authorize (accept quote)
@@ -506,7 +506,7 @@ sequenceDiagram
     participant Escrow as Escrow Agent
     participant Blockchain
 
-    Requester->>Provider: Exchange (USDC → EURC)
+    Requester->>Provider: RFQ (USDC → EURC)
     Provider->>Requester: Quote (rates & amounts)
     Note over Requester: User reviews quote
     Requester->>Provider: Authorize (accept quote)
@@ -547,7 +547,7 @@ sequenceDiagram
     participant EscrowB as Escrow Agent B
     participant Blockchain
 
-    Requester->>Provider: Exchange (USDC → EURC)
+    Requester->>Provider: RFQ (USDC → EURC)
     Provider->>Requester: Quote (rates & amounts)
     Requester->>Provider: Authorize (accept quote)
 
@@ -592,9 +592,9 @@ sequenceDiagram
     participant LP3 as Provider 3
     participant Blockchain
 
-    Requester->>LP1: Exchange (multiple assets)
-    Requester->>LP2: Exchange (multiple assets)
-    Requester->>LP3: Exchange (multiple assets)
+    Requester->>LP1: RFQ (multiple assets)
+    Requester->>LP2: RFQ (multiple assets)
+    Requester->>LP3: RFQ (multiple assets)
 
     LP1->>Requester: Quote (rate: 0.91)
     LP2->>Requester: Quote (rate: 0.92)

--- a/messages.md
+++ b/messages.md
@@ -373,22 +373,22 @@ Initiates a payment request from a merchant to a customer.
 ```
 
 ### RFQ
-[TAIP-18] - Draft
+[TAIP-18] - Review
 
 Requests a quote for exchanging assets between different types or chains. Enables cross-asset quotes (e.g., USDC to EURC, USD to USDC).
 
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
-| @context | string | Yes | Draft ([TAIP-18]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
-| @type | string | Yes | Draft ([TAIP-18]) | JSON-LD type "https://tap.rsvp/schema/1.0#RFQ" |
-| fromAssets | array of string | Yes | Draft ([TAIP-18]) | Available source assets (CAIP-19, DTI, or ISO-4217 currency codes) |
-| toAssets | array of string | Yes | Draft ([TAIP-18]) | Desired target assets (CAIP-19, DTI, or ISO-4217 currency codes) |
-| fromAmount | string | No | Draft ([TAIP-18]) | Amount of source asset to exchange. Either fromAmount or toAmount must be provided |
-| toAmount | string | No | Draft ([TAIP-18]) | Amount of target asset desired. Either fromAmount or toAmount must be provided |
-| requester | [Party](#party) | Yes | Draft ([TAIP-18]) | Party requesting the exchange |
-| provider | [Party](#party) | No | Draft ([TAIP-18]) | Optional preferred liquidity provider. When omitted, RFQ can be broadcast to multiple providers |
-| agents | array of [Agent](#agent) | Yes | Draft ([TAIP-18]) | Array of agents involved in the RFQ |
-| policies | array of [Policy](#policy) | No | Draft ([TAIP-18]) | Optional compliance or presentation requirements |
+| @context | string | Yes | Review ([TAIP-18]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
+| @type | string | Yes | Review ([TAIP-18]) | JSON-LD type "https://tap.rsvp/schema/1.0#RFQ" |
+| fromAssets | array of string | Yes | Review ([TAIP-18]) | Available source assets (CAIP-19, DTI, or ISO-4217 currency codes) |
+| toAssets | array of string | Yes | Review ([TAIP-18]) | Desired target assets (CAIP-19, DTI, or ISO-4217 currency codes) |
+| fromAmount | string | No | Review ([TAIP-18]) | Amount of source asset to exchange. Either fromAmount or toAmount must be provided |
+| toAmount | string | No | Review ([TAIP-18]) | Amount of target asset desired. Either fromAmount or toAmount must be provided |
+| requester | [Party](#party) | Yes | Review ([TAIP-18]) | Party requesting the exchange |
+| provider | [Party](#party) | No | Review ([TAIP-18]) | Optional preferred liquidity provider. When omitted, RFQ can be broadcast to multiple providers |
+| agents | array of [Agent](#agent) | Yes | Review ([TAIP-18]) | Array of agents involved in the RFQ |
+| policies | array of [Policy](#policy) | No | Review ([TAIP-18]) | Optional compliance or presentation requirements |
 
 #### Example
 ```json
@@ -432,21 +432,21 @@ Requests a quote for exchanging assets between different types or chains. Enable
 ```
 
 ### Quote
-[TAIP-18] - Draft
+[TAIP-18] - Review
 
 Response to an RFQ providing pricing and terms. Sent by liquidity providers or orchestrators with specific rates.
 
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
-| @context | string | Yes | Draft ([TAIP-18]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
-| @type | string | Yes | Draft ([TAIP-18]) | JSON-LD type "https://tap.rsvp/schema/1.0#Quote" |
-| fromAsset | string | Yes | Draft ([TAIP-18]) | Source asset for the exchange (CAIP-19, DTI, or ISO-4217 currency code) |
-| toAsset | string | Yes | Draft ([TAIP-18]) | Target asset for the exchange (CAIP-19, DTI, or ISO-4217 currency code) |
-| fromAmount | string | Yes | Draft ([TAIP-18]) | Amount of source asset to be exchanged |
-| toAmount | string | Yes | Draft ([TAIP-18]) | Amount of target asset to be received |
-| provider | [Party](#party) | Yes | Draft ([TAIP-18]) | Liquidity provider party information |
-| agents | array of [Agent](#agent) | Yes | Draft ([TAIP-18]) | Array of agents involved in the quote |
-| expiresAt | string | Yes | Draft ([TAIP-18]) | ISO 8601 timestamp when quote expires |
+| @context | string | Yes | Review ([TAIP-18]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
+| @type | string | Yes | Review ([TAIP-18]) | JSON-LD type "https://tap.rsvp/schema/1.0#Quote" |
+| fromAsset | string | Yes | Review ([TAIP-18]) | Source asset for the exchange (CAIP-19, DTI, or ISO-4217 currency code) |
+| toAsset | string | Yes | Review ([TAIP-18]) | Target asset for the exchange (CAIP-19, DTI, or ISO-4217 currency code) |
+| fromAmount | string | Yes | Review ([TAIP-18]) | Amount of source asset to be exchanged |
+| toAmount | string | Yes | Review ([TAIP-18]) | Amount of target asset to be received |
+| provider | [Party](#party) | Yes | Review ([TAIP-18]) | Liquidity provider party information |
+| agents | array of [Agent](#agent) | Yes | Review ([TAIP-18]) | Array of agents involved in the quote |
+| expiresAt | string | Yes | Review ([TAIP-18]) | ISO 8601 timestamp when quote expires |
 
 #### Example
 ```json

--- a/messages.md
+++ b/messages.md
@@ -372,7 +372,7 @@ Initiates a payment request from a merchant to a customer.
 }
 ```
 
-### Exchange
+### RFQ
 [TAIP-18] - Draft
 
 Requests a quote for exchanging assets between different types or chains. Enables cross-asset quotes (e.g., USDC to EURC, USD to USDC).
@@ -380,28 +380,28 @@ Requests a quote for exchanging assets between different types or chains. Enable
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
 | @context | string | Yes | Draft ([TAIP-18]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
-| @type | string | Yes | Draft ([TAIP-18]) | JSON-LD type "https://tap.rsvp/schema/1.0#Exchange" |
+| @type | string | Yes | Draft ([TAIP-18]) | JSON-LD type "https://tap.rsvp/schema/1.0#RFQ" |
 | fromAssets | array of string | Yes | Draft ([TAIP-18]) | Available source assets (CAIP-19, DTI, or ISO-4217 currency codes) |
 | toAssets | array of string | Yes | Draft ([TAIP-18]) | Desired target assets (CAIP-19, DTI, or ISO-4217 currency codes) |
 | fromAmount | string | No | Draft ([TAIP-18]) | Amount of source asset to exchange. Either fromAmount or toAmount must be provided |
 | toAmount | string | No | Draft ([TAIP-18]) | Amount of target asset desired. Either fromAmount or toAmount must be provided |
 | requester | [Party](#party) | Yes | Draft ([TAIP-18]) | Party requesting the exchange |
-| provider | [Party](#party) | No | Draft ([TAIP-18]) | Optional preferred liquidity provider. When omitted, Exchange can be broadcast to multiple providers |
-| agents | array of [Agent](#agent) | Yes | Draft ([TAIP-18]) | Array of agents involved in the exchange request |
+| provider | [Party](#party) | No | Draft ([TAIP-18]) | Optional preferred liquidity provider. When omitted, RFQ can be broadcast to multiple providers |
+| agents | array of [Agent](#agent) | Yes | Draft ([TAIP-18]) | Array of agents involved in the RFQ |
 | policies | array of [Policy](#policy) | No | Draft ([TAIP-18]) | Optional compliance or presentation requirements |
 
 #### Example
 ```json
 {
-  "id": "exchange-request-123",
-  "type": "https://tap.rsvp/schema/1.0#Exchange",
+  "id": "rfq-123",
+  "type": "https://tap.rsvp/schema/1.0#RFQ",
   "from": "did:web:wallet.example",
   "to": ["did:web:lp.example"],
   "created_time": 1719226800,
   "expires_time": 1719313200,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Exchange",
+    "@type": "https://tap.rsvp/schema/1.0#RFQ",
     "fromAssets": ["eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
     "toAssets": ["eip155:1/erc20:0xB00b00b00b00b00b00b00b00b00b00b00b00b00b"],
     "fromAmount": "1000.00",
@@ -434,7 +434,7 @@ Requests a quote for exchanging assets between different types or chains. Enable
 ### Quote
 [TAIP-18] - Draft
 
-Response to an Exchange request providing pricing and terms. Sent by liquidity providers or orchestrators with specific rates.
+Response to an RFQ providing pricing and terms. Sent by liquidity providers or orchestrators with specific rates.
 
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
@@ -455,7 +455,7 @@ Response to an Exchange request providing pricing and terms. Sent by liquidity p
   "type": "https://tap.rsvp/schema/1.0#Quote",
   "from": "did:web:lp.example",
   "to": ["did:web:wallet.example"],
-  "thid": "exchange-request-123",
+  "thid": "rfq-123",
   "created_time": 1719226850,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the TypeScript package are documented in this file.
 
+## [2.0.0] - 2026-05-01
+
+### Changed (Breaking)
+- **TAIP-18 RFQ rename**: Renamed `Exchange` message type to `RFQ` (Request for Quote) based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
+  - `Exchange` interface → `RFQ`
+  - `ExchangeMessage` interface → `RFQMessage`
+  - `ExchangeSchema` validator → `RFQSchema`
+  - `ExchangeMessageSchema` validator → `RFQMessageSchema`
+  - `validateExchangeMessage` → `validateRFQMessage`
+  - `arbitraries.messageBodies.exchange` → `arbitraries.messageBodies.rfq`
+  - `arbitraries.messages.exchangeMessage` → `arbitraries.messages.rfqMessage`
+  - DIDComm `type` URI updated from `https://tap.rsvp/schema/1.0#Exchange` to `https://tap.rsvp/schema/1.0#RFQ`
+  - JSON-LD `@type` value updated from `Exchange` to `RFQ`
+
 ## [1.14.0] - 2025-11-23
 
 ### Changed

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taprsvp/types",
-  "version": "1.14.0",
+  "version": "2.0.0",
   "description": "TypeScript types and interfaces for the Transaction Authorization Protocol (TAP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/typescript/src/arbitraries.ts
+++ b/packages/typescript/src/arbitraries.ts
@@ -18,7 +18,7 @@ import type {
   Agent,
   Transfer,
   Payment,
-  Exchange,
+  RFQ,
   Quote,
   Escrow,
   Capture,
@@ -30,7 +30,7 @@ import type {
   Revert,
   TransferMessage,
   PaymentMessage,
-  ExchangeMessage,
+  RFQMessage,
   QuoteMessage,
   EscrowMessage,
   CaptureMessage,
@@ -263,11 +263,11 @@ export const payment = (): fc.Arbitrary<Payment> =>
     purposeCode: fc.option(fc.constantFrom("TRAD", "SALA", "RENT", "INTC", "SUPP"), { nil: undefined })
   });
 
-export const exchange = (): fc.Arbitrary<Exchange> =>
+export const rfq = (): fc.Arbitrary<RFQ> =>
   fc.oneof(
     fc.record({
       "@context": fc.constant("https://tap.rsvp/schema/1.0" as const),
-      "@type": fc.constant("Exchange" as const),
+      "@type": fc.constant("RFQ" as const),
       fromAssets: fc.array(fc.oneof(caip19(), isoCurrency()), { minLength: 1, maxLength: 5 }),
       toAssets: fc.array(fc.oneof(caip19(), isoCurrency()), { minLength: 1, maxLength: 5 }),
       fromAmount: amount(),
@@ -277,7 +277,7 @@ export const exchange = (): fc.Arbitrary<Exchange> =>
     }),
     fc.record({
       "@context": fc.constant("https://tap.rsvp/schema/1.0" as const),
-      "@type": fc.constant("Exchange" as const),
+      "@type": fc.constant("RFQ" as const),
       fromAssets: fc.array(fc.oneof(caip19(), isoCurrency()), { minLength: 1, maxLength: 5 }),
       toAssets: fc.array(fc.oneof(caip19(), isoCurrency()), { minLength: 1, maxLength: 5 }),
       toAmount: amount(),
@@ -428,14 +428,14 @@ export const paymentMessage = (): fc.Arbitrary<PaymentMessage> =>
     thid: fc.option(uuid(), { nil: undefined })
   });
 
-export const exchangeMessage = (): fc.Arbitrary<ExchangeMessage> =>
+export const rfqMessage = (): fc.Arbitrary<RFQMessage> =>
   fc.record({
     id: uuid(),
-    type: fc.constant("https://tap.rsvp/schema/1.0#Exchange" as const),
+    type: fc.constant("https://tap.rsvp/schema/1.0#RFQ" as const),
     from: did(),
     to: fc.array(did(), { minLength: 1, maxLength: 1 }),
     created_time: fc.integer({ min: Date.now() - 86400000, max: Date.now() }),
-    body: exchange(),
+    body: rfq(),
     thid: fc.option(uuid(), { nil: undefined })
   });
 
@@ -541,8 +541,8 @@ export const revertMessage = (): fc.Arbitrary<RevertMessage> =>
 export const tapMessage = (): fc.Arbitrary<TAPMessage> =>
   fc.oneof(
     transferMessage(),
-    paymentMessage(), 
-    exchangeMessage(),
+    paymentMessage(),
+    rfqMessage(),
     quoteMessage(),
     escrowMessage(),
     captureMessage(),
@@ -584,7 +584,7 @@ export const arbitraries = {
   messageBodies: {
     transfer: () => transfer(),
     payment: () => payment(),
-    exchange: () => exchange(),
+    rfq: () => rfq(),
     quote: () => quote(),
     escrow: () => escrow(),
     capture: () => capture(),
@@ -600,7 +600,7 @@ export const arbitraries = {
   messages: {
     transferMessage: () => transferMessage(),
     paymentMessage: () => paymentMessage(),
-    exchangeMessage: () => exchangeMessage(),
+    rfqMessage: () => rfqMessage(),
     quoteMessage: () => quoteMessage(),
     escrowMessage: () => escrowMessage(),
     captureMessage: () => captureMessage(),

--- a/packages/typescript/src/tap.ts
+++ b/packages/typescript/src/tap.ts
@@ -1109,7 +1109,7 @@ export type Policies =
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-14.md | TAIP-14: Payment Request}
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md | TAIP-17: Escrow}
  */
-export type Transactions = Transfer | Payment | Exchange | Escrow;
+export type Transactions = Transfer | Payment | RFQ | Escrow;
 
 /**
  * Transfer Message
@@ -1332,15 +1332,15 @@ export interface Payment extends TapMessageObject<"Payment"> {
 }
 
 /**
- * Exchange Message
+ * RFQ (Request for Quote) Message
  * Requests a quote for exchanging assets between different types or chains.
  * Used to request cross-asset quotes (e.g., USDC to EURC, USD to USDC).
  *
  * @example
  * ```typescript
- * const exchange: Exchange = {
+ * const rfq: RFQ = {
  *   "@context": "https://tap.rsvp/schema/1.0",
- *   "@type": "Exchange",
+ *   "@type": "RFQ",
  *   fromAssets: ["eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"], // USDC
  *   toAssets: ["eip155:1/erc20:0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c"], // EURC
  *   fromAmount: "1000.00",
@@ -1359,7 +1359,7 @@ export interface Payment extends TapMessageObject<"Payment"> {
  *
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-18.md | TAIP-18: Asset Exchange}
  */
-export interface Exchange extends TapMessageObject<"Exchange"> {
+export interface RFQ extends TapMessageObject<"RFQ"> {
   /**
    * Array of available source assets
    * Can include CAIP-19, DTI, or ISO-4217 currency codes
@@ -1394,12 +1394,12 @@ export interface Exchange extends TapMessageObject<"Exchange"> {
 
   /**
    * Optional preferred liquidity provider
-   * When omitted, the Exchange can be broadcast to multiple providers
+   * When omitted, the RFQ can be broadcast to multiple providers
    */
   provider?: Party;
 
   /**
-   * List of agents involved in the exchange request
+   * List of agents involved in the RFQ
    * Must include agent acting for the requester
    */
   agents: Agent[];
@@ -1413,7 +1413,7 @@ export interface Exchange extends TapMessageObject<"Exchange"> {
 
 /**
  * Quote Message
- * Response to an Exchange request providing pricing and terms.
+ * Response to an RFQ providing pricing and terms.
  * Sent by liquidity providers or orchestrators with specific rates.
  *
  * @example
@@ -1474,7 +1474,7 @@ export interface Quote extends TapMessageObject<"Quote"> {
 
   /**
    * List of agents involved in the quote
-   * Must include all agents from the original Exchange request plus provider agents
+   * Must include all agents from the original RFQ plus provider agents
    */
   agents: Agent[];
 
@@ -2056,14 +2056,14 @@ export interface PaymentMessage extends DIDCommMessage<Payment> {
 }
 
 /**
- * Exchange Message Wrapper
- * DIDComm envelope for an Exchange message.
+ * RFQ Message Wrapper
+ * DIDComm envelope for an RFQ (Request for Quote) message.
  *
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-2.md | TAIP-2: Message Format}
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-18.md | TAIP-18: Asset Exchange}
  */
-export interface ExchangeMessage extends DIDCommMessage<Exchange> {
-  type: "https://tap.rsvp/schema/1.0#Exchange";
+export interface RFQMessage extends DIDCommMessage<RFQ> {
+  type: "https://tap.rsvp/schema/1.0#RFQ";
 }
 
 /**
@@ -2427,7 +2427,7 @@ export interface PresentationMessage
 export type TAPMessage =
   | TransferMessage
   | PaymentMessage
-  | ExchangeMessage
+  | RFQMessage
   | QuoteMessage
   | AuthorizeMessage
   | SettleMessage
@@ -2464,7 +2464,7 @@ export type TAPMessage =
  * - TAIP-4: Authorization Flow → {@link Authorize}, {@link Settle}, {@link Reject}, {@link Cancel}, {@link Revert}, {@link AuthorizationRequired}
  * - TAIP-14: Payment Request → {@link Payment}, {@link PaymentMessage}
  * - TAIP-17: Composable Escrow → {@link Escrow}, {@link Capture}, {@link EscrowMessage}, {@link CaptureMessage}
- * - TAIP-18: Asset Exchange → {@link Exchange}, {@link Quote}, {@link ExchangeMessage}, {@link QuoteMessage}
+ * - TAIP-18: Asset Exchange → {@link RFQ}, {@link Quote}, {@link RFQMessage}, {@link QuoteMessage}
  *
  * **Participant Management:**
  * - TAIP-5: Agents → {@link Agent}, {@link UpdateAgent}, {@link AddAgents}, {@link ReplaceAgent}, {@link RemoveAgent}

--- a/packages/typescript/src/validator.test.ts
+++ b/packages/typescript/src/validator.test.ts
@@ -38,7 +38,7 @@ import {
   // Message validators
   TransferSchema,
   PaymentSchema,
-  ExchangeSchema,
+  RFQSchema,
   QuoteSchema,
   EscrowSchema,
   CaptureSchema,
@@ -52,7 +52,7 @@ import {
   // DIDComm wrapped validators
   TransferMessageSchema,
   PaymentMessageSchema,
-  ExchangeMessageSchema,
+  RFQMessageSchema,
   QuoteMessageSchema,
   EscrowMessageSchema,
   CaptureMessageSchema,
@@ -70,7 +70,7 @@ import {
   isTAPMessage,
   validateTransferMessage,
   validatePaymentMessage,
-  validateExchangeMessage,
+  validateRFQMessage,
   validateQuoteMessage,
   validateEscrowMessage,
   validateCaptureMessage,
@@ -494,32 +494,32 @@ describe('TAP Message Validators', () => {
     });
   });
 
-  describe('ExchangeSchema', () => {
-    it('should validate exchange with fromAmount', () => {
-      const exchange = {
+  describe('RFQSchema', () => {
+    it('should validate RFQ with fromAmount', () => {
+      const rfq = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: ["USD"],
         toAssets: ["eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
         fromAmount: "1000.00",
         requester: validPerson,
         agents: [validAgent]
       };
-      expect(ExchangeSchema.safeParse(exchange).success).toBe(true);
+      expect(RFQSchema.safeParse(rfq).success).toBe(true);
     });
 
-    it('should validate generated exchange messages', () => {
+    it('should validate generated RFQ messages', () => {
       fc.assert(
-        fc.property(arbitraries.messageBodies.exchange(), (exchange) => {
-          expect(ExchangeSchema.safeParse(exchange).success).toBe(true);
+        fc.property(arbitraries.messageBodies.rfq(), (rfq) => {
+          expect(RFQSchema.safeParse(rfq).success).toBe(true);
         })
       );
     });
 
-    it('should validate exchange with toAmount', () => {
-      const exchange = {
+    it('should validate RFQ with toAmount', () => {
+      const rfq = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: ["USD"],
         toAssets: ["EUR"],
         toAmount: "900.00",
@@ -527,45 +527,45 @@ describe('TAP Message Validators', () => {
         provider: validPerson,
         agents: [validAgent]
       };
-      expect(ExchangeSchema.safeParse(exchange).success).toBe(true);
+      expect(RFQSchema.safeParse(rfq).success).toBe(true);
     });
 
-    it('should validate exchange with multiple assets', () => {
-      const exchange = {
+    it('should validate RFQ with multiple assets', () => {
+      const rfq = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: ["USD", "EUR"],
         toAssets: ["eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f"],
         fromAmount: "1000.00",
         requester: validPerson,
         agents: [validAgent]
       };
-      expect(ExchangeSchema.safeParse(exchange).success).toBe(true);
+      expect(RFQSchema.safeParse(rfq).success).toBe(true);
     });
 
     it('should require either fromAmount or toAmount', () => {
-      const exchange = {
+      const rfq = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: ["USD"],
         toAssets: ["EUR"],
         requester: validPerson,
         agents: [validAgent]
       };
-      expect(ExchangeSchema.safeParse(exchange).success).toBe(false);
+      expect(RFQSchema.safeParse(rfq).success).toBe(false);
     });
 
     it('should require at least one fromAsset and toAsset', () => {
-      const exchange = {
+      const rfq = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: [],
         toAssets: ["EUR"],
         fromAmount: "1000.00",
         requester: validPerson,
         agents: [validAgent]
       };
-      expect(ExchangeSchema.safeParse(exchange).success).toBe(false);
+      expect(RFQSchema.safeParse(rfq).success).toBe(false);
     });
   });
 
@@ -756,9 +756,9 @@ describe('DIDComm Message Validators', () => {
     agents: [{ "@id": "did:example:agent", for: "did:example:alice", name: "Agent" }]
   };
 
-  const validExchangeBody = {
+  const validRFQBody = {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "Exchange",
+    "@type": "RFQ",
     fromAssets: ["USD"],
     toAssets: ["EUR"],
     fromAmount: "1000.00",
@@ -830,23 +830,23 @@ describe('DIDComm Message Validators', () => {
     });
   });
 
-  describe('ExchangeMessageSchema', () => {
-    it('should validate valid exchange messages', () => {
+  describe('RFQMessageSchema', () => {
+    it('should validate valid RFQ messages', () => {
       const message = {
         id: "01234567-89ab-4def-a123-456789abcdef",
-        type: "https://tap.rsvp/schema/1.0#Exchange",
+        type: "https://tap.rsvp/schema/1.0#RFQ",
         from: "did:example:sender",
         to: ["did:example:receiver"],
         created_time: Date.now(),
-        body: validExchangeBody
+        body: validRFQBody
       };
-      expect(ExchangeMessageSchema.safeParse(message).success).toBe(true);
+      expect(RFQMessageSchema.safeParse(message).success).toBe(true);
     });
 
-    it('should validate generated exchange messages', () => {
+    it('should validate generated RFQ messages', () => {
       fc.assert(
-        fc.property(arbitraries.messages.exchangeMessage(), (message) => {
-          expect(ExchangeMessageSchema.safeParse(message).success).toBe(true);
+        fc.property(arbitraries.messages.rfqMessage(), (message) => {
+          expect(RFQMessageSchema.safeParse(message).success).toBe(true);
         })
       );
     });
@@ -858,9 +858,9 @@ describe('DIDComm Message Validators', () => {
         from: "did:example:sender",
         to: ["did:example:receiver"],
         created_time: Date.now(),
-        body: validExchangeBody
+        body: validRFQBody
       };
-      expect(ExchangeMessageSchema.safeParse(message).success).toBe(false);
+      expect(RFQMessageSchema.safeParse(message).success).toBe(false);
     });
   });
 
@@ -1007,15 +1007,15 @@ describe('TAPMessageSchema (Discriminated Union)', () => {
       }
     };
 
-    const exchangeMessage = {
+    const rfqMessage = {
       id: "12345678-9abc-4def-a123-456789abcdef",
-      type: "https://tap.rsvp/schema/1.0#Exchange",
+      type: "https://tap.rsvp/schema/1.0#RFQ",
       from: "did:example:requester",
       to: ["did:example:provider"],
       created_time: Date.now(),
       body: {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: ["USD"],
         toAssets: ["EUR"],
         fromAmount: "1000.00",
@@ -1057,7 +1057,7 @@ describe('TAPMessageSchema (Discriminated Union)', () => {
     };
 
     expect(TAPMessageSchema.safeParse(transferMessage).success).toBe(true);
-    expect(TAPMessageSchema.safeParse(exchangeMessage).success).toBe(true);
+    expect(TAPMessageSchema.safeParse(rfqMessage).success).toBe(true);
     expect(TAPMessageSchema.safeParse(escrowMessage).success).toBe(true);
     expect(TAPMessageSchema.safeParse(authorizeMessage).success).toBe(true);
   });
@@ -1163,15 +1163,15 @@ describe('Validation Functions', () => {
   });
 
   describe('Message-specific validators', () => {
-    const validExchangeMessage = {
+    const validRFQMessage = {
       id: "12345678-9abc-4def-a123-456789abcdef",
-      type: "https://tap.rsvp/schema/1.0#Exchange",
+      type: "https://tap.rsvp/schema/1.0#RFQ",
       from: "did:example:requester",
       to: ["did:example:provider"],
       created_time: Date.now(),
       body: {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Exchange",
+        "@type": "RFQ",
         fromAssets: ["USD"],
         toAssets: ["EUR"],
         fromAmount: "1000.00",
@@ -1238,8 +1238,8 @@ describe('Validation Functions', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should validate exchange messages', () => {
-      const result = validateExchangeMessage(validExchangeMessage);
+    it('should validate RFQ messages', () => {
+      const result = validateRFQMessage(validRFQMessage);
       expect(result.success).toBe(true);
     });
 
@@ -1264,8 +1264,8 @@ describe('Validation Functions', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject non-exchange messages for exchange validator', () => {
-      const result = validateExchangeMessage(validMessage);
+    it('should reject non-RFQ messages for RFQ validator', () => {
+      const result = validateRFQMessage(validMessage);
       expect(result.success).toBe(false);
     });
 

--- a/packages/typescript/src/validator.ts
+++ b/packages/typescript/src/validator.ts
@@ -279,9 +279,9 @@ export const RevertSchema = TapMessageObjectSchema.merge(z.object({
   txHash: z.string().optional()
 }));
 
-/** Exchange message body validator */
-export const ExchangeSchema = TapMessageObjectSchema.merge(z.object({
-  "@type": z.literal("Exchange"),
+/** RFQ message body validator */
+export const RFQSchema = TapMessageObjectSchema.merge(z.object({
+  "@type": z.literal("RFQ"),
   fromAssets: z.array(AssetSchema).min(1),
   toAssets: z.array(AssetSchema).min(1),
   fromAmount: AmountSchema.optional(),
@@ -380,10 +380,10 @@ export const RevertMessageSchema = DIDCommReplySchema.merge(z.object({
   body: RevertSchema
 }));
 
-/** Exchange DIDComm message validator */
-export const ExchangeMessageSchema = DIDCommMessageSchema.merge(z.object({
-  type: z.literal("https://tap.rsvp/schema/1.0#Exchange"),
-  body: ExchangeSchema
+/** RFQ DIDComm message validator */
+export const RFQMessageSchema = DIDCommMessageSchema.merge(z.object({
+  type: z.literal("https://tap.rsvp/schema/1.0#RFQ"),
+  body: RFQSchema
 }));
 
 /** Quote DIDComm reply validator */
@@ -412,7 +412,7 @@ export const CaptureMessageSchema = DIDCommReplySchema.merge(z.object({
 export const TAPMessageSchema = z.discriminatedUnion("type", [
   TransferMessageSchema,
   PaymentMessageSchema,
-  ExchangeMessageSchema,
+  RFQMessageSchema,
   QuoteMessageSchema,
   EscrowMessageSchema,
   CaptureMessageSchema,
@@ -484,8 +484,8 @@ export const validateCancelMessage = (message: unknown) => CancelMessageSchema.s
 /** Validates Revert messages */
 export const validateRevertMessage = (message: unknown) => RevertMessageSchema.safeParse(message);
 
-/** Validates Exchange messages */
-export const validateExchangeMessage = (message: unknown) => ExchangeMessageSchema.safeParse(message);
+/** Validates RFQ messages */
+export const validateRFQMessage = (message: unknown) => RFQMessageSchema.safeParse(message);
 
 /** Validates Quote messages */
 export const validateQuoteMessage = (message: unknown) => QuoteMessageSchema.safeParse(message);

--- a/schemas/messages/quote.json
+++ b/schemas/messages/quote.json
@@ -75,7 +75,7 @@
             "$ref": "../data-structures/agent.json"
           },
           "minItems": 1,
-          "description": "Agents involved in the quote (must include all from original Exchange plus provider agents)"
+          "description": "Agents involved in the quote (must include all from original RFQ plus provider agents)"
         },
         "expiresAt": {
           "$ref": "../common/base-types.json#/$defs/iso8601DateTime",

--- a/schemas/messages/rfq.json
+++ b/schemas/messages/rfq.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://taips.tap.rsvp/schemas/messages/exchange.json",
-  "title": "Exchange Message",
-  "description": "Asset exchange request message per TAIP-18",
+  "$id": "https://taips.tap.rsvp/schemas/messages/rfq.json",
+  "title": "RFQ Message",
+  "description": "Request for Quote (RFQ) message per TAIP-18",
   "type": "object",
   "allOf": [
     {
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "type": {
-      "const": "https://tap.rsvp/schema/1.0#Exchange"
+      "const": "https://tap.rsvp/schema/1.0#RFQ"
     },
     "body": {
       "type": "object",
@@ -29,7 +29,7 @@
           "const": "https://tap.rsvp/schema/1.0"
         },
         "@type": {
-          "const": "https://tap.rsvp/schema/1.0#Exchange"
+          "const": "https://tap.rsvp/schema/1.0#RFQ"
         },
         "fromAssets": {
           "type": "array",
@@ -95,7 +95,7 @@
             "$ref": "../data-structures/agent.json"
           },
           "minItems": 1,
-          "description": "Agents involved in the exchange request"
+          "description": "Agents involved in the RFQ"
         },
         "policies": {
           "type": "array",


### PR DESCRIPTION
## Summary

- Renames the TAIP-18 `Exchange` message type to `RFQ` (Request for Quote) based on feedback from both payment and institutional users, who recognized RFQ as the standard name for this pattern in payments and institutional finance
- Preserves "Asset Exchange" as the protocol's title and conceptual references ("exchange flow", "exchange complete"); only the specific message identifier changed
- Updates TAIP-18, TAIP-14 cross-references, `messages.md`, JSON schema (renamed `exchange.json` → `rfq.json`), and the TypeScript SDK
- TypeScript SDK bumped to `2.0.0` since `Exchange` / `ExchangeMessage` / `ExchangeSchema` / `ExchangeMessageSchema` / `validateExchangeMessage` and the matching arbitraries are renamed

### Wire-format changes

| Before | After |
| --- | --- |
| `https://tap.rsvp/schema/1.0#Exchange` (DIDComm `type`) | `https://tap.rsvp/schema/1.0#RFQ` |
| `@type: "Exchange"` (body) | `@type: "RFQ"` |
| `schemas/messages/exchange.json` | `schemas/messages/rfq.json` |

### TypeScript SDK renames

- `Exchange` → `RFQ`
- `ExchangeMessage` → `RFQMessage`
- `ExchangeSchema` → `RFQSchema`
- `ExchangeMessageSchema` → `RFQMessageSchema`
- `validateExchangeMessage` → `validateRFQMessage`
- `arbitraries.messageBodies.exchange` → `arbitraries.messageBodies.rfq`
- `arbitraries.messages.exchangeMessage` → `arbitraries.messages.rfqMessage`

## Test plan

- [x] `cd schemas && npm run validate` — schemas load cleanly (31 schemas)
- [x] `cd packages/typescript && npm run type-check` — passes
- [x] `cd packages/typescript && npm run test:run` — 144/144 tests pass
- [x] `cd packages/typescript && npm run build` — passes
- [ ] Reviewer to confirm naming choice and that "Asset Exchange" is the right thing to keep as the spec title

🤖 Generated with [Claude Code](https://claude.com/claude-code)