### PR TITLE
Rename TAIP-17 Escrow message type to Lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ This changelog focuses on:
 ## [2026-05-01]
 
 ### Changed
+- **TAIP-17 Composable Escrow**: Renamed `Escrow` message type to `Lock` based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
+  - Message type identifier `https://tap.rsvp/schema/1.0#Escrow` is now `https://tap.rsvp/schema/1.0#Lock`
+  - JSON-LD `@type` value changed from `Escrow` to `Lock`
+  - Schema file renamed from `schemas/messages/escrow.json` to `schemas/messages/lock.json`
+  - Test vectors moved from `test-vectors/escrow/` to `test-vectors/lock/`
+  - TypeScript: `Escrow`/`EscrowMessage` types renamed to `Lock`/`LockMessage`; validators and arbitraries renamed accordingly
+  - "Composable Escrow" remains the TAIP title and the `EscrowAgent` role name is preserved; only the specific message identifier changed
+  - TAIP-18 examples and flow diagrams updated to reference `Lock` instead of `Escrow`
 - **TAIP-18 Asset Exchange**: Status advanced from Draft to Review
 - **TAIP-18 Asset Exchange**: Renamed `Exchange` message type to `RFQ` (Request for Quote) based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
   - Message type identifier `https://tap.rsvp/schema/1.0#Exchange` is now `https://tap.rsvp/schema/1.0#RFQ`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog focuses on:
 ## [2026-05-01]
 
 ### Changed
+- **TAIP-17 Composable Escrow**: Status advanced from Draft to Review
 - **TAIP-17 Composable Escrow**: Renamed `Escrow` message type to `Lock` based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
   - Message type identifier `https://tap.rsvp/schema/1.0#Escrow` is now `https://tap.rsvp/schema/1.0#Lock`
   - JSON-LD `@type` value changed from `Escrow` to `Lock`

--- a/TAIPs/taip-17.md
+++ b/TAIPs/taip-17.md
@@ -5,18 +5,18 @@ status: Draft
 type: Standard
 author: Pelle Braendgaard <pelle@notabene.id>
 created: 2025-06-24
-updated: 2025-06-24
-description: Defines Escrow and Capture message types for holding and releasing funds on behalf of parties, enabling payment guarantees and asset swaps. Specifies the complete escrow lifecycle from acceptance through capture, with clear authorization rules for each stage while maintaining compatibility with existing TAP messages.
+updated: 2026-05-01
+description: Defines Lock and Capture message types for holding and releasing funds on behalf of parties, enabling payment guarantees and asset swaps. Specifies the complete escrow lifecycle from acceptance through capture, with clear authorization rules for each stage while maintaining compatibility with existing TAP messages.
 requires: 2, 4, 5, 6, 7
 ---
 
 ## Simple Summary
 
-Introduces **Escrow** and **Capture** message types that allow agents to hold and release assets on behalf of parties during a transaction. The escrow can be captured (released to beneficiary) or cancelled (returned to originator), enabling payment guarantee flows (like credit card authorization/capture) and secure asset swaps between parties.
+Introduces **Lock** and **Capture** message types that allow agents to hold and release assets on behalf of parties during a transaction. The escrow can be captured (released to beneficiary) or cancelled (returned to originator), enabling payment guarantee flows (like credit card authorization/capture) and secure asset swaps between parties.
 
 ## Abstract
 
-This proposal defines a composable **Escrow** workflow within the Transaction Authorization Protocol. An Escrow message allows one agent to request another agent to hold a specified amount of currency or asset from a party in escrow on behalf of another party. The specification introduces a **Capture** message for beneficiaries to authorize the release of escrowed funds, and defines the complete lifecycle including acceptance by the escrow agent, activation through settlement, and release or cancellation. The workflow reuses existing TAP messages (Authorize, Settle, Cancel) from [TAIP-4] and can optionally leverage [TAIP-3] for returning cancelled funds. This enables various use cases including payment guarantees for merchants, asset swaps between parties, and conditional payments that require multi-party authorization before settlement.
+This proposal defines a composable escrow workflow within the Transaction Authorization Protocol. A **Lock** message allows one agent to request another agent to hold a specified amount of currency or asset from a party in escrow on behalf of another party. The specification introduces a **Capture** message for beneficiaries to authorize the release of escrowed funds, and defines the complete lifecycle including acceptance by the escrow agent, activation through settlement, and release or cancellation. The workflow reuses existing TAP messages (Authorize, Settle, Cancel) from [TAIP-4] and can optionally leverage [TAIP-3] for returning cancelled funds. This enables various use cases including payment guarantees for merchants, asset swaps between parties, and conditional payments that require multi-party authorization before settlement.
 
 ## Motivation
 
@@ -27,15 +27,15 @@ Current blockchain transactions are immediate and irreversible, making it challe
 3. **Conditional Payments**: Where funds should only be released upon meeting certain conditions
 4. **Multi-party Transactions**: Where multiple parties need to approve before funds are released
 
-By introducing an Escrow message type, TAP can support these advanced workflows while maintaining its core principles of agent-based authorization and composability. The escrow agent acts as a trusted intermediary, holding assets until conditions are met for release or cancellation.
+By introducing a Lock message type, TAP can support these advanced workflows while maintaining its core principles of agent-based authorization and composability. The escrow agent acts as a trusted intermediary, holding assets until conditions are met for release or cancellation.
 
 ## Specification
 
 ### Roles and Participants
 
-The Escrow workflow involves several distinct roles:
+The escrow workflow involves several distinct roles:
 
-1. **Initiator**: The agent that creates and sends the Escrow request (identified by `from` in the DIDComm envelope)
+1. **Initiator**: The agent that creates and sends the Lock request (identified by `from` in the DIDComm envelope)
 2. **Escrow Agent**: The agent that receives the request and holds the assets in escrow (identified by the `EscrowAgent` role the `agents` array)
 3. **Originator**: The party whose assets will be placed in escrow (consistent with TAIP-3 terminology)
 4. **Beneficiary**: The party who will receive the assets if the escrow is released
@@ -47,14 +47,14 @@ The authorization model is simple: agents acting for the beneficiary (as indicat
 
 **Policies**: Agents MAY declare policies per [TAIP-7] to specify their requirements for participating in the escrow. For example, an escrow agent might require `RequirePresentation` for KYC verification or `RequireAuthorization` from specific parties before accepting the escrow role.
 
-### Escrow Message
+### Lock Message
 
-An **Escrow** is a [DIDComm] message (per [TAIP-2]) that requests an agent to hold assets in escrow. Like all TAP messages, it follows the DIDComm v2 message structure with the TAP-specific body format.
+A **Lock** is a [DIDComm] message (per [TAIP-2]) that requests an agent to hold assets in escrow. Like all TAP messages, it follows the DIDComm v2 message structure with the TAP-specific body format.
 
 The DIDComm message envelope contains:
-- **`from`** – REQUIRED [DID] of the initiator agent (the agent requesting the escrow)
+- **`from`** – REQUIRED [DID] of the initiator agent (the agent requesting the lock)
 - **`to`** – REQUIRED Array containing [DID] of the agents taking part in the escrow process
-- **`type`** – REQUIRED Message type: `"https://tap.rsvp/schema/1.0#Escrow"`
+- **`type`** – REQUIRED Message type: `"https://tap.rsvp/schema/1.0#Lock"`
 - **`id`** – REQUIRED Unique message identifier
 - **`thid`** – OPTIONAL Thread identifier for related messages. Eg. a `Payment` ([TAIP-14])
 - **`created_time`** – REQUIRED Message creation timestamp
@@ -62,7 +62,7 @@ The DIDComm message envelope contains:
 
 The message `body` contains:
 - **`@context`** – REQUIRED JSON-LD context: `"https://tap.rsvp/schema/1.0"`
-- **`@type`** – REQUIRED Type identifier: `"https://tap.rsvp/schema/1.0#Escrow"`
+- **`@type`** – REQUIRED Type identifier: `"https://tap.rsvp/schema/1.0#Lock"`
 - **`asset`** – OPTIONAL The specific cryptocurrency asset to be held in escrow ([CAIP-19] identifier). Either `asset` OR `currency` MUST be present
 - **`currency`** – OPTIONAL ISO 4217 currency code (e.g. "USD", "EUR") for fiat-denominated escrows. Either `asset` OR `currency` MUST be present
 - **`amount`** – REQUIRED The amount to be held in escrow (string decimal)
@@ -78,7 +78,7 @@ An escrow progresses through the following states:
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Requested : Escrow
+    [*] --> Requested : Lock
     Requested --> Accepted : Authorize (from EscrowAgent)
     Requested --> Rejected : Reject
     Accepted --> Active : Settle (from originator's agent)
@@ -95,7 +95,7 @@ stateDiagram-v2
 
 The escrow workflow follows this sequence:
 
-1. **Escrow Request**: Initiating agent sends Escrow message to all involved agents
+1. **Lock Request**: Initiating agent sends Lock message to all involved agents
 2. **Escrow Acceptance**: The EscrowAgent responds with Authorize to accept the escrow role
    - If EscrowAgent also acts `for` the originator, funds are locked internally
    - Otherwise, Authorize MUST include a `settlementAddress` for the originator to send funds
@@ -134,7 +134,7 @@ The DIDComm message envelope contains:
 - **`to`** – REQUIRED Array containing [DID] of the EscrowAgent
 - **`type`** – REQUIRED Message type: `"https://tap.rsvp/schema/1.0#Capture"`
 - **`id`** – REQUIRED Unique message identifier
-- **`thid`** – REQUIRED Thread identifier linking to the original Escrow message
+- **`thid`** – REQUIRED Thread identifier linking to the original Lock message
 
 The message `body` contains:
 - **`@context`** – REQUIRED JSON-LD context: `"https://tap.rsvp/schema/1.0"`
@@ -149,14 +149,14 @@ This example shows a merchant requesting a payment guarantee from a customer, fo
 ```json
 {
   "id": "123e4567-e89b-12d3-a456-426614174000",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:merchant.example",
   "to": ["did:web:paymentprocessor.example"],
   "created_time": 1719226800,
   "expires_time": 1719313200,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     "amount": "100.00",
     "originator": {
@@ -198,12 +198,12 @@ This example demonstrates an atomic swap between two parties where each party cr
 ```json
 {
   "id": "swap-alice-to-bob",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:alice.wallet",
   "to": ["did:web:swap.service"],
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     "amount": "100.00",
     "originator": {
@@ -246,12 +246,12 @@ This example shows an escrow denominated in fiat currency:
 ```json
 {
   "id": "789e0123-e89b-12d3-a456-426614174003",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:marketplace.example",
   "to": ["did:web:escrow.bank"],
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "currency": "USD",
     "amount": "500.00",
     "originator": {
@@ -292,12 +292,12 @@ This example shows the originator's wallet provider acting as the escrow agent:
 ```json
 {
   "id": "internal-escrow-123",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:alice.wallet",
   "to": ["did:web:alice.wallet"],
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     "amount": "250.00",
     "originator": {
@@ -334,12 +334,12 @@ This example shows an escrow agent requiring verification before accepting the e
 ```json
 {
   "id": "policy-escrow-456",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:marketplace.example",
   "to": ["did:web:compliant.escrow"],
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     "amount": "1000.00",
     "originator": {
@@ -388,7 +388,7 @@ In this example:
 
 ### Composability with Other TAP Messages
 
-The Escrow workflow is designed to be composable with other TAP messages:
+The escrow workflow is designed to be composable with other TAP messages:
 
 1. **With Transfer**: An escrow can be created as part of a Transfer flow
 2. **With Payment**: Merchants can require escrow before shipping goods
@@ -472,13 +472,13 @@ The `expiry` timestamp is required for all escrows:
 
 ## Privacy Considerations
 
-1. **Minimal Disclosure**: Escrow messages should not contain unnecessary party information
+1. **Minimal Disclosure**: Lock messages should not contain unnecessary party information
 2. **Selective Revelation**: Use [TAIP-8] for sharing additional details only when required
 3. **Transaction Linkability**: Multiple escrows may be linkable if using same agents
 
 ## Backwards Compatibility
 
-This TAIP introduces a new message type and does not modify existing messages. Agents not supporting Escrow will reject such messages as unsupported, maintaining compatibility with existing TAP implementations.
+This TAIP introduces a new message type and does not modify existing messages. Agents not supporting Lock will reject such messages as unsupported, maintaining compatibility with existing TAP implementations.
 
 ## References
 

--- a/TAIPs/taip-17.md
+++ b/TAIPs/taip-17.md
@@ -1,7 +1,7 @@
 ---
 taip: 17
 title: Composable Escrow
-status: Draft
+status: Review
 type: Standard
 author: Pelle Braendgaard <pelle@notabene.id>
 created: 2025-06-24

--- a/TAIPs/taip-18.md
+++ b/TAIPs/taip-18.md
@@ -365,15 +365,15 @@ After a Quote is accepted via Authorize, the provider can request escrow using [
 
 ```json
 {
-  "id": "escrow-for-exchange-123",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "id": "lock-for-exchange-123",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:lp.example",
   "to": ["did:web:alice.wallet", "did:web:escrow.service"],
   "pthid": "quote-456",
   "created_time": 1719227000,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "asset": "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     "amount": "1000.00",
     "originator": {
@@ -401,7 +401,7 @@ After a Quote is accepted via Authorize, the provider can request escrow using [
 }
 ```
 
-Note how the Escrow message:
+Note how the Lock message:
 - Uses `pthid: "quote-456"` to link to the accepted Quote
 - Sets the requester as `originator` (their funds go into escrow)
 - Sets the provider as `beneficiary` (they receive funds after exchange)
@@ -457,7 +457,7 @@ stateDiagram-v2
     [*] --> Requested : RFQ
     Requested --> Quoted : Quote received
     Quoted --> Authorized : Authorize sent
-    Authorized --> EscrowRequested : Escrow received (optional)
+    Authorized --> EscrowRequested : Lock received (optional)
     Authorized --> Settling : Direct settlement
     EscrowRequested --> EscrowActive : Escrow funded
     EscrowActive --> Settling : Capture sent
@@ -497,7 +497,7 @@ sequenceDiagram
 
 ### Exchange Flow with Escrow
 
-Either party can manage counterparty risk by requesting escrow after a Quote is accepted. This leverages [TAIP-17] Escrow messages with the `pthid` field linking to the Quote:
+Either party can manage counterparty risk by requesting escrow after a Quote is accepted. This leverages [TAIP-17] Lock messages with the `pthid` field linking to the Quote:
 
 ```mermaid
 sequenceDiagram
@@ -512,8 +512,8 @@ sequenceDiagram
     Requester->>Provider: Authorize (accept quote)
 
     Note over Provider: Provider wants escrow protection
-    Provider->>Requester: Escrow (pthid: quote-456)
-    Provider->>Escrow: Escrow (pthid: quote-456)
+    Provider->>Requester: Lock (pthid: quote-456)
+    Provider->>Escrow: Lock (pthid: quote-456)
 
     Escrow->>Requester: Authorize (accept escrow role)
     Escrow->>Provider: Authorize (settlement address)
@@ -552,14 +552,14 @@ sequenceDiagram
     Requester->>Provider: Authorize (accept quote)
 
     par Requester Escrow Setup
-        Provider->>Requester: Escrow A (requester's funds)
-        Provider->>EscrowA: Escrow A (pthid: quote-456)
+        Provider->>Requester: Lock A (requester's funds)
+        Provider->>EscrowA: Lock A (pthid: quote-456)
         EscrowA->>Requester: Authorize
         Requester->>Blockchain: Fund Escrow A
         Requester->>EscrowA: Settle
     and Provider Escrow Setup
-        Requester->>Provider: Escrow B (provider's funds)
-        Requester->>EscrowB: Escrow B (pthid: quote-456)
+        Requester->>Provider: Lock B (provider's funds)
+        Requester->>EscrowB: Lock B (pthid: quote-456)
         EscrowB->>Provider: Authorize
         Provider->>Blockchain: Fund Escrow B
         Provider->>EscrowB: Settle
@@ -615,7 +615,7 @@ sequenceDiagram
 ```
 
 Key aspects of the escrow flow:
-- **Uses `pthid`**: Escrow messages reference the Quote via parent thread ID
+- **Uses `pthid`**: Lock messages reference the Quote via parent thread ID
 - **Standard [TAIP-17] flow**: Follows established escrow patterns
 - **Flexible initiation**: Either party can request escrow
 - **Atomic execution**: With dual escrow, both complete or both fail
@@ -626,7 +626,7 @@ Key aspects of the escrow flow:
 TAIP-18 can be embedded as a subflow in:
 
 * `Payment` workflows ([TAIP-14]) for invoice settlement
-* `Escrow` workflows ([TAIP-17]) for guaranteed payment with FX conversion
+* `Lock` workflows ([TAIP-17]) for guaranteed payment with FX conversion
 * On-ramp/off-ramp flows between fiat and crypto assets
 * Cross-border remittance with currency conversion
 * Multi-asset portfolio rebalancing

--- a/messages.md
+++ b/messages.md
@@ -12,7 +12,7 @@ permalink: /messages/
 - [Transaction Message](#transaction-message)
   - [Transfer](#transfer)
   - [Payment](#payment)
-  - [Escrow](#escrow)
+  - [Lock](#lock)
 - [Authorization Flow Messages](#authorization-flow-messages)
   - [AuthorizationRequired](#authorizationrequired)
   - [Authorize](#authorize)
@@ -486,7 +486,7 @@ Response to an RFQ providing pricing and terms. Sent by liquidity providers or o
 }
 ```
 
-### Escrow
+### Lock
 [TAIP-17] - Draft
 
 Requests an agent to hold assets in escrow on behalf of parties, enabling payment guarantees and asset swaps.
@@ -494,7 +494,7 @@ Requests an agent to hold assets in escrow on behalf of parties, enabling paymen
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
 | @context | string | Yes | Draft ([TAIP-17]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
-| @type | string | Yes | Draft ([TAIP-17]) | JSON-LD type "https://tap.rsvp/schema/1.0#Escrow" |
+| @type | string | Yes | Draft ([TAIP-17]) | JSON-LD type "https://tap.rsvp/schema/1.0#Lock" |
 | asset | string | No | Draft ([TAIP-17]) | CAIP-19 identifier for the specific cryptocurrency asset. Either asset OR currency must be present |
 | currency | string | No | Draft ([TAIP-17]) | ISO 4217 currency code for fiat-denominated escrows. Either asset OR currency must be present |
 | amount | string | Yes | Draft ([TAIP-17]) | Amount to be held in escrow (decimal string) |
@@ -506,18 +506,18 @@ Requests an agent to hold assets in escrow on behalf of parties, enabling paymen
 
 #### Examples
 
-##### Payment guarantee escrow
+##### Payment guarantee lock
 ```json
 {
   "id": "123e4567-e89b-12d3-a456-426614174000",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:merchant.example",
   "to": ["did:web:paymentprocessor.example"],
   "created_time": 1719226800,
   "expires_time": 1719313200,
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     "amount": "100.00",
     "originator": {
@@ -546,16 +546,16 @@ Requests an agent to hold assets in escrow on behalf of parties, enabling paymen
 }
 ```
 
-##### Fiat currency escrow
+##### Fiat currency lock
 ```json
 {
   "id": "789e0123-e89b-12d3-a456-426614174003",
-  "type": "https://tap.rsvp/schema/1.0#Escrow",
+  "type": "https://tap.rsvp/schema/1.0#Lock",
   "from": "did:web:marketplace.example",
   "to": ["did:web:escrow.bank"],
   "body": {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "https://tap.rsvp/schema/1.0#Escrow",
+    "@type": "https://tap.rsvp/schema/1.0#Lock",
     "currency": "USD",
     "amount": "500.00",
     "originator": {
@@ -862,7 +862,7 @@ Authorizes the release of escrowed funds to the beneficiary. Only agents acting 
 | amount | string | No | Draft ([TAIP-17]) | Amount to capture (decimal string). If omitted, captures full escrow amount. Must be ≤ original amount |
 | settlementAddress | string | No | Draft ([TAIP-17]) | Blockchain address for settlement. If omitted, uses address from earlier Authorize |
 
-> **Note:** The message refers to the original Escrow message via the DIDComm `thid` (thread ID) in the message envelope.
+> **Note:** The message refers to the original Lock message via the DIDComm `thid` (thread ID) in the message envelope.
 
 #### Examples
 

--- a/messages.md
+++ b/messages.md
@@ -487,22 +487,22 @@ Response to an RFQ providing pricing and terms. Sent by liquidity providers or o
 ```
 
 ### Lock
-[TAIP-17] - Draft
+[TAIP-17] - Review
 
 Requests an agent to hold assets in escrow on behalf of parties, enabling payment guarantees and asset swaps.
 
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
-| @context | string | Yes | Draft ([TAIP-17]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
-| @type | string | Yes | Draft ([TAIP-17]) | JSON-LD type "https://tap.rsvp/schema/1.0#Lock" |
-| asset | string | No | Draft ([TAIP-17]) | CAIP-19 identifier for the specific cryptocurrency asset. Either asset OR currency must be present |
-| currency | string | No | Draft ([TAIP-17]) | ISO 4217 currency code for fiat-denominated escrows. Either asset OR currency must be present |
-| amount | string | Yes | Draft ([TAIP-17]) | Amount to be held in escrow (decimal string) |
-| originator | [Party](#party) | Yes | Draft ([TAIP-17]) | Party whose assets will be placed in escrow |
-| beneficiary | [Party](#party) | Yes | Draft ([TAIP-17]) | Party who will receive the assets when released |
-| expiry | string | Yes | Draft ([TAIP-17]) | ISO 8601 timestamp after which the escrow automatically expires |
-| agreement | string | No | Draft ([TAIP-17]) | URL or URI referencing the terms and conditions of the escrow |
-| agents | array of [Agent](#agent) | Yes | Draft ([TAIP-17]) | Array of agents involved in the escrow. Exactly one agent MUST have role "EscrowAgent" |
+| @context | string | Yes | Review ([TAIP-17]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
+| @type | string | Yes | Review ([TAIP-17]) | JSON-LD type "https://tap.rsvp/schema/1.0#Lock" |
+| asset | string | No | Review ([TAIP-17]) | CAIP-19 identifier for the specific cryptocurrency asset. Either asset OR currency must be present |
+| currency | string | No | Review ([TAIP-17]) | ISO 4217 currency code for fiat-denominated escrows. Either asset OR currency must be present |
+| amount | string | Yes | Review ([TAIP-17]) | Amount to be held in escrow (decimal string) |
+| originator | [Party](#party) | Yes | Review ([TAIP-17]) | Party whose assets will be placed in escrow |
+| beneficiary | [Party](#party) | Yes | Review ([TAIP-17]) | Party who will receive the assets when released |
+| expiry | string | Yes | Review ([TAIP-17]) | ISO 8601 timestamp after which the escrow automatically expires |
+| agreement | string | No | Review ([TAIP-17]) | URL or URI referencing the terms and conditions of the escrow |
+| agents | array of [Agent](#agent) | Yes | Review ([TAIP-17]) | Array of agents involved in the escrow. Exactly one agent MUST have role "EscrowAgent" |
 
 #### Examples
 
@@ -851,16 +851,16 @@ Requests a reversal of a settled transaction. This could be part of a dispute re
 ```
 
 ### Capture
-[TAIP-17] - Draft
+[TAIP-17] - Review
 
 Authorizes the release of escrowed funds to the beneficiary. Only agents acting for the beneficiary can send this message.
 
 | Attribute | Type | Required | Status | Description |
 |-----------|------|----------|---------|-------------|
-| @context | string | Yes | Draft ([TAIP-17]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
-| @type | string | Yes | Draft ([TAIP-17]) | JSON-LD type "https://tap.rsvp/schema/1.0#Capture" |
-| amount | string | No | Draft ([TAIP-17]) | Amount to capture (decimal string). If omitted, captures full escrow amount. Must be ≤ original amount |
-| settlementAddress | string | No | Draft ([TAIP-17]) | Blockchain address for settlement. If omitted, uses address from earlier Authorize |
+| @context | string | Yes | Review ([TAIP-17]) | JSON-LD context "https://tap.rsvp/schema/1.0" |
+| @type | string | Yes | Review ([TAIP-17]) | JSON-LD type "https://tap.rsvp/schema/1.0#Capture" |
+| amount | string | No | Review ([TAIP-17]) | Amount to capture (decimal string). If omitted, captures full escrow amount. Must be ≤ original amount |
+| settlementAddress | string | No | Review ([TAIP-17]) | Blockchain address for settlement. If omitted, uses address from earlier Authorize |
 
 > **Note:** The message refers to the original Lock message via the DIDComm `thid` (thread ID) in the message envelope.
 

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the TypeScript package are documented in this file.
 ## [2.0.0] - 2026-05-01
 
 ### Changed (Breaking)
+- **TAIP-17 Lock rename**: Renamed `Escrow` message type to `Lock` based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
+  - `Escrow` interface → `Lock`
+  - `EscrowMessage` interface → `LockMessage`
+  - `EscrowSchema` validator → `LockSchema`
+  - `EscrowMessageSchema` validator → `LockMessageSchema`
+  - `validateEscrowMessage` → `validateLockMessage`
+  - `arbitraries.messageBodies.escrow` → `arbitraries.messageBodies.lock`
+  - `arbitraries.messages.escrowMessage` → `arbitraries.messages.lockMessage`
+  - DIDComm `type` URI updated from `https://tap.rsvp/schema/1.0#Escrow` to `https://tap.rsvp/schema/1.0#Lock`
+  - JSON-LD `@type` value updated from `Escrow` to `Lock`
+  - The `EscrowAgent` role name (in the `agents` array) is preserved
 - **TAIP-18 RFQ rename**: Renamed `Exchange` message type to `RFQ` (Request for Quote) based on feedback from both payment and institutional users, who recognized the term as the standard name for this pattern in payments and institutional finance
   - `Exchange` interface → `RFQ`
   - `ExchangeMessage` interface → `RFQMessage`

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -183,12 +183,12 @@ const agent = arbitraries.participants.agent();
 // Generate complete TAP message bodies
 const transfer = arbitraries.messageBodies.transfer();
 const payment = arbitraries.messageBodies.payment();
-const exchange = arbitraries.messageBodies.exchange();
+const rfq = arbitraries.messageBodies.rfq();
 const quote = arbitraries.messageBodies.quote();
-const escrow = arbitraries.messageBodies.escrow();
+const lock = arbitraries.messageBodies.lock();
 
 // All message types available:
-// transfer, payment, exchange, quote, escrow, capture,
+// transfer, payment, rfq, quote, lock, capture,
 // authorize, connect, settle, reject, cancel, revert
 ```
 
@@ -409,7 +409,7 @@ The package includes TypeScript interfaces for all TAP message types:
 |--------------|-------------|----------------|
 | `Transfer` | Asset transfer requests | [TAIP-3](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-3.md) |
 | `Payment` | Merchant payment requests | [TAIP-14](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-14.md) |
-| `Escrow` | Conditional asset holding | [TAIP-17](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md) |
+| `Lock` | Conditional asset holding | [TAIP-17](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md) |
 | `Authorize` | Transaction authorization | [TAIP-4](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-4.md) |
 | `Connect` | Agent connection establishment | [TAIP-15](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-15.md) |
 | `Settle` | Settlement confirmation | [TAIP-4](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-4.md) |

--- a/packages/typescript/src/arbitraries.ts
+++ b/packages/typescript/src/arbitraries.ts
@@ -20,7 +20,7 @@ import type {
   Payment,
   RFQ,
   Quote,
-  Escrow,
+  Lock,
   Capture,
   Authorize,
   Connect,
@@ -32,7 +32,7 @@ import type {
   PaymentMessage,
   RFQMessage,
   QuoteMessage,
-  EscrowMessage,
+  LockMessage,
   CaptureMessage,
   AuthorizeMessage,
   ConnectMessage,
@@ -304,10 +304,10 @@ export const quote = (): fc.Arbitrary<Quote> =>
     )
   });
 
-export const escrow = (): fc.Arbitrary<Escrow> =>
+export const lock = (): fc.Arbitrary<Lock> =>
   fc.record({
     "@context": fc.constant("https://tap.rsvp/schema/1.0" as const),
-    "@type": fc.constant("Escrow" as const),
+    "@type": fc.constant("Lock" as const),
     asset: caip19(),
     amount: amount(),
     originator: party(),
@@ -450,14 +450,14 @@ export const quoteMessage = (): fc.Arbitrary<QuoteMessage> =>
     body: quote()
   });
 
-export const escrowMessage = (): fc.Arbitrary<EscrowMessage> =>
+export const lockMessage = (): fc.Arbitrary<LockMessage> =>
   fc.record({
     id: uuid(),
-    type: fc.constant("https://tap.rsvp/schema/1.0#Escrow" as const),
+    type: fc.constant("https://tap.rsvp/schema/1.0#Lock" as const),
     from: did(),
     to: fc.array(did(), { minLength: 1, maxLength: 1 }),
     created_time: fc.integer({ min: Date.now() - 86400000, max: Date.now() }),
-    body: escrow(),
+    body: lock(),
     thid: fc.option(uuid(), { nil: undefined })
   });
 
@@ -544,7 +544,7 @@ export const tapMessage = (): fc.Arbitrary<TAPMessage> =>
     paymentMessage(),
     rfqMessage(),
     quoteMessage(),
-    escrowMessage(),
+    lockMessage(),
     captureMessage(),
     authorizeMessage(),
     connectMessage(),
@@ -586,7 +586,7 @@ export const arbitraries = {
     payment: () => payment(),
     rfq: () => rfq(),
     quote: () => quote(),
-    escrow: () => escrow(),
+    lock: () => lock(),
     capture: () => capture(),
     authorize: () => authorize(),
     connect: () => connect(),
@@ -602,7 +602,7 @@ export const arbitraries = {
     paymentMessage: () => paymentMessage(),
     rfqMessage: () => rfqMessage(),
     quoteMessage: () => quoteMessage(),
-    escrowMessage: () => escrowMessage(),
+    lockMessage: () => lockMessage(),
     captureMessage: () => captureMessage(),
     authorizeMessage: () => authorizeMessage(),
     connectMessage: () => connectMessage(),

--- a/packages/typescript/src/tap.ts
+++ b/packages/typescript/src/tap.ts
@@ -14,7 +14,7 @@
  * ## Core Message Types
  * - `Transfer` - Initiate asset transfers between parties
  * - `Payment` - Request payments from customers (merchant-initiated)
- * - `Escrow` - Hold assets in escrow with conditional release
+ * - `Lock` - Hold assets in escrow with conditional release
  * - `Authorize` - Approve transactions after compliance checks
  * - `Connect` - Establish connections between agents
  * - `Settle` - Confirm on-chain settlement
@@ -1107,9 +1107,9 @@ export type Policies =
  *
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-3.md | TAIP-3: Transfer Message}
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-14.md | TAIP-14: Payment Request}
- * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md | TAIP-17: Escrow}
+ * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md | TAIP-17: Composable Escrow}
  */
-export type Transactions = Transfer | Payment | RFQ | Escrow;
+export type Transactions = Transfer | Payment | RFQ | Lock;
 
 /**
  * Transfer Message
@@ -2244,13 +2244,13 @@ export interface AuthorizationRequiredMessage
 }
 
 /**
- * Escrow Message
- * Requests an agent to hold assets in escrow on behalf of parties.
+ * Lock Message
+ * Requests an agent to hold (lock) assets in escrow on behalf of parties.
  * Enables payment guarantees, asset swaps, and conditional payments.
  *
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md | TAIP-17: Composable Escrow}
  */
-export interface Escrow extends TapMessageObject<"Escrow"> {
+export interface Lock extends TapMessageObject<"Lock"> {
   /**
    * Asset to be held in escrow
    * CAIP-19 identifier for blockchain assets
@@ -2326,14 +2326,14 @@ export interface Capture extends TapMessageObject<"Capture"> {
 }
 
 /**
- * Escrow Message Wrapper
- * DIDComm envelope for an Escrow message.
+ * Lock Message Wrapper
+ * DIDComm envelope for a Lock message.
  *
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-2.md | TAIP-2: Message Format}
  * @see {@link https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/TAIPs/taip-17.md | TAIP-17: Composable Escrow}
  */
-export interface EscrowMessage extends DIDCommMessage<Escrow> {
-  type: "https://tap.rsvp/schema/1.0#Escrow";
+export interface LockMessage extends DIDCommMessage<Lock> {
+  type: "https://tap.rsvp/schema/1.0#Lock";
 }
 
 /**
@@ -2443,7 +2443,7 @@ export type TAPMessage =
   | UpdatePoliciesMessage
   | ConnectMessage
   | AuthorizationRequiredMessage
-  | EscrowMessage
+  | LockMessage
   | CaptureMessage
   | PresentationMessage;
 
@@ -2463,7 +2463,7 @@ export type TAPMessage =
  * - TAIP-3: Transfer Message → {@link Transfer}, {@link TransferMessage}
  * - TAIP-4: Authorization Flow → {@link Authorize}, {@link Settle}, {@link Reject}, {@link Cancel}, {@link Revert}, {@link AuthorizationRequired}
  * - TAIP-14: Payment Request → {@link Payment}, {@link PaymentMessage}
- * - TAIP-17: Composable Escrow → {@link Escrow}, {@link Capture}, {@link EscrowMessage}, {@link CaptureMessage}
+ * - TAIP-17: Composable Escrow → {@link Lock}, {@link Capture}, {@link LockMessage}, {@link CaptureMessage}
  * - TAIP-18: Asset Exchange → {@link RFQ}, {@link Quote}, {@link RFQMessage}, {@link QuoteMessage}
  *
  * **Participant Management:**

--- a/packages/typescript/src/validator.test.ts
+++ b/packages/typescript/src/validator.test.ts
@@ -40,7 +40,7 @@ import {
   PaymentSchema,
   RFQSchema,
   QuoteSchema,
-  EscrowSchema,
+  LockSchema,
   CaptureSchema,
   AuthorizeSchema,
   ConnectSchema,
@@ -54,7 +54,7 @@ import {
   PaymentMessageSchema,
   RFQMessageSchema,
   QuoteMessageSchema,
-  EscrowMessageSchema,
+  LockMessageSchema,
   CaptureMessageSchema,
   AuthorizeMessageSchema,
   ConnectMessageSchema,
@@ -72,7 +72,7 @@ import {
   validatePaymentMessage,
   validateRFQMessage,
   validateQuoteMessage,
-  validateEscrowMessage,
+  validateLockMessage,
   validateCaptureMessage,
   validateAuthorizeMessage,
   validateConnectMessage,
@@ -604,11 +604,11 @@ describe('TAP Message Validators', () => {
     });
   });
 
-  describe('EscrowSchema', () => {
-    it('should validate escrow with asset', () => {
-      const escrow = {
+  describe('LockSchema', () => {
+    it('should validate lock with asset', () => {
+      const lock = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Escrow",
+        "@type": "Lock",
         asset: "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         amount: "1000.00",
         originator: validPerson,
@@ -616,21 +616,21 @@ describe('TAP Message Validators', () => {
         expiry: "2025-07-21T01:00:00Z",
         agents: [validAgent]
       };
-      expect(EscrowSchema.safeParse(escrow).success).toBe(true);
+      expect(LockSchema.safeParse(lock).success).toBe(true);
     });
 
-    it('should validate generated escrow messages', () => {
+    it('should validate generated lock messages', () => {
       fc.assert(
-        fc.property(arbitraries.messageBodies.escrow(), (escrow) => {
-          expect(EscrowSchema.safeParse(escrow).success).toBe(true);
+        fc.property(arbitraries.messageBodies.lock(), (lock) => {
+          expect(LockSchema.safeParse(lock).success).toBe(true);
         })
       );
     });
 
-    it('should validate escrow with currency', () => {
-      const escrow = {
+    it('should validate lock with currency', () => {
+      const lock = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Escrow",
+        "@type": "Lock",
         currency: "USD",
         amount: "1000.00",
         originator: validPerson,
@@ -639,29 +639,29 @@ describe('TAP Message Validators', () => {
         agreement: "https://example.com/escrow-terms",
         agents: [validAgent]
       };
-      expect(EscrowSchema.safeParse(escrow).success).toBe(true);
+      expect(LockSchema.safeParse(lock).success).toBe(true);
     });
 
     it('should require either asset or currency', () => {
-      const escrow = {
+      const lock = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Escrow",
+        "@type": "Lock",
         amount: "1000.00",
         originator: validPerson,
         beneficiary: validPerson,
         expiry: "2025-07-21T01:00:00Z",
         agents: [validAgent]
       };
-      expect(EscrowSchema.safeParse(escrow).success).toBe(false);
+      expect(LockSchema.safeParse(lock).success).toBe(false);
     });
 
     it('should require all required fields', () => {
-      const escrow = {
+      const lock = {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Escrow",
+        "@type": "Lock",
         asset: "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
       };
-      expect(EscrowSchema.safeParse(escrow).success).toBe(false);
+      expect(LockSchema.safeParse(lock).success).toBe(false);
     });
   });
 
@@ -778,9 +778,9 @@ describe('DIDComm Message Validators', () => {
     expiresAt: "2025-07-21T00:00:00Z"
   };
 
-  const validEscrowBody = {
+  const validLockBody = {
     "@context": "https://tap.rsvp/schema/1.0",
-    "@type": "Escrow",
+    "@type": "Lock",
     asset: "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     amount: "1000.00",
     originator: { "@id": "did:example:alice", name: "Alice" },
@@ -891,17 +891,17 @@ describe('DIDComm Message Validators', () => {
     });
   });
 
-  describe('EscrowMessageSchema', () => {
-    it('should validate valid escrow messages', () => {
+  describe('LockMessageSchema', () => {
+    it('should validate valid lock messages', () => {
       const message = {
         id: "01234567-89ab-4def-a123-456789abcdef",
-        type: "https://tap.rsvp/schema/1.0#Escrow",
+        type: "https://tap.rsvp/schema/1.0#Lock",
         from: "did:example:sender",
         to: ["did:example:receiver"],
         created_time: Date.now(),
-        body: validEscrowBody
+        body: validLockBody
       };
-      expect(EscrowMessageSchema.safeParse(message).success).toBe(true);
+      expect(LockMessageSchema.safeParse(message).success).toBe(true);
     });
 
     it('should reject wrong message type', () => {
@@ -911,9 +911,9 @@ describe('DIDComm Message Validators', () => {
         from: "did:example:sender",
         to: ["did:example:receiver"],
         created_time: Date.now(),
-        body: validEscrowBody
+        body: validLockBody
       };
-      expect(EscrowMessageSchema.safeParse(message).success).toBe(false);
+      expect(LockMessageSchema.safeParse(message).success).toBe(false);
     });
   });
 
@@ -1024,15 +1024,15 @@ describe('TAPMessageSchema (Discriminated Union)', () => {
       }
     };
 
-    const escrowMessage = {
+    const lockMessage = {
       id: "23456789-abcd-4ef0-a123-456789abcdef",
-      type: "https://tap.rsvp/schema/1.0#Escrow",
+      type: "https://tap.rsvp/schema/1.0#Lock",
       from: "did:example:originator",
       to: ["did:example:beneficiary"],
       created_time: Date.now(),
       body: {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Escrow",
+        "@type": "Lock",
         asset: "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         amount: "1000.00",
         originator: { "@id": "did:example:alice", name: "Alice" },
@@ -1058,7 +1058,7 @@ describe('TAPMessageSchema (Discriminated Union)', () => {
 
     expect(TAPMessageSchema.safeParse(transferMessage).success).toBe(true);
     expect(TAPMessageSchema.safeParse(rfqMessage).success).toBe(true);
-    expect(TAPMessageSchema.safeParse(escrowMessage).success).toBe(true);
+    expect(TAPMessageSchema.safeParse(lockMessage).success).toBe(true);
     expect(TAPMessageSchema.safeParse(authorizeMessage).success).toBe(true);
   });
 
@@ -1200,15 +1200,15 @@ describe('Validation Functions', () => {
       }
     };
 
-    const validEscrowMessage = {
+    const validLockMessage = {
       id: "34567890-bcde-4f01-a123-456789abcdef",
-      type: "https://tap.rsvp/schema/1.0#Escrow",
+      type: "https://tap.rsvp/schema/1.0#Lock",
       from: "did:example:originator",
       to: ["did:example:beneficiary"],
       created_time: Date.now(),
       body: {
         "@context": "https://tap.rsvp/schema/1.0",
-        "@type": "Escrow",
+        "@type": "Lock",
         asset: "eip155:1/erc20:0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         amount: "1000.00",
         originator: { "@id": "did:example:alice", name: "Alice" },
@@ -1248,8 +1248,8 @@ describe('Validation Functions', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should validate escrow messages', () => {
-      const result = validateEscrowMessage(validEscrowMessage);
+    it('should validate lock messages', () => {
+      const result = validateLockMessage(validLockMessage);
       expect(result.success).toBe(true);
     });
 
@@ -1274,8 +1274,8 @@ describe('Validation Functions', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject non-escrow messages for escrow validator', () => {
-      const result = validateEscrowMessage(validMessage);
+    it('should reject non-lock messages for lock validator', () => {
+      const result = validateLockMessage(validMessage);
       expect(result.success).toBe(false);
     });
 

--- a/packages/typescript/src/validator.ts
+++ b/packages/typescript/src/validator.ts
@@ -306,9 +306,9 @@ export const QuoteSchema = TapMessageObjectSchema.merge(z.object({
   expiresAt: ISO8601DateTimeSchema
 }));
 
-/** Escrow message body validator */
-export const EscrowSchema = TapMessageObjectSchema.merge(z.object({
-  "@type": z.literal("Escrow"),
+/** Lock message body validator */
+export const LockSchema = TapMessageObjectSchema.merge(z.object({
+  "@type": z.literal("Lock"),
   asset: CAIP19Schema.optional(),
   currency: CurrencyCodeSchema.optional(),
   amount: AmountSchema,
@@ -392,10 +392,10 @@ export const QuoteMessageSchema = DIDCommReplySchema.merge(z.object({
   body: QuoteSchema
 }));
 
-/** Escrow DIDComm message validator */
-export const EscrowMessageSchema = DIDCommMessageSchema.merge(z.object({
-  type: z.literal("https://tap.rsvp/schema/1.0#Escrow"),
-  body: EscrowSchema
+/** Lock DIDComm message validator */
+export const LockMessageSchema = DIDCommMessageSchema.merge(z.object({
+  type: z.literal("https://tap.rsvp/schema/1.0#Lock"),
+  body: LockSchema
 }));
 
 /** Capture DIDComm reply validator */
@@ -414,7 +414,7 @@ export const TAPMessageSchema = z.discriminatedUnion("type", [
   PaymentMessageSchema,
   RFQMessageSchema,
   QuoteMessageSchema,
-  EscrowMessageSchema,
+  LockMessageSchema,
   CaptureMessageSchema,
   AuthorizeMessageSchema,
   ConnectMessageSchema,
@@ -490,8 +490,8 @@ export const validateRFQMessage = (message: unknown) => RFQMessageSchema.safePar
 /** Validates Quote messages */
 export const validateQuoteMessage = (message: unknown) => QuoteMessageSchema.safeParse(message);
 
-/** Validates Escrow messages */
-export const validateEscrowMessage = (message: unknown) => EscrowMessageSchema.safeParse(message);
+/** Validates Lock messages */
+export const validateLockMessage = (message: unknown) => LockMessageSchema.safeParse(message);
 
 /** Validates Capture messages */
 export const validateCaptureMessage = (message: unknown) => CaptureMessageSchema.safeParse(message);

--- a/schemas/messages/capture.json
+++ b/schemas/messages/capture.json
@@ -15,7 +15,7 @@
     },
     "thid": {
       "$ref": "../common/base-types.json#/$defs/uuid",
-      "description": "Thread identifier linking to the original Escrow message"
+      "description": "Thread identifier linking to the original Lock message"
     },
     "body": {
       "type": "object",

--- a/schemas/messages/lock.json
+++ b/schemas/messages/lock.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://taips.tap.rsvp/schemas/messages/escrow.json",
-  "title": "Escrow Message",
-  "description": "Requests an agent to hold assets in escrow on behalf of parties",
+  "$id": "https://taips.tap.rsvp/schemas/messages/lock.json",
+  "title": "Lock Message",
+  "description": "Requests an agent to hold (lock) assets in escrow on behalf of parties",
   "type": "object",
   "allOf": [
     {
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "type": {
-      "const": "https://tap.rsvp/schema/1.0#Escrow"
+      "const": "https://tap.rsvp/schema/1.0#Lock"
     },
     "body": {
       "type": "object",
@@ -30,7 +30,7 @@
           "description": "JSON-LD context"
         },
         "@type": {
-          "const": "https://tap.rsvp/schema/1.0#Escrow",
+          "const": "https://tap.rsvp/schema/1.0#Lock",
           "description": "Type identifier"
         },
         "asset": {

--- a/test-vectors/lock/invalid-missing-beneficiary.json
+++ b/test-vectors/lock/invalid-missing-beneficiary.json
@@ -1,18 +1,18 @@
 {
-  "description": "Invalid escrow request missing beneficiary",
-  "purpose": "Validates that escrow messages must include a beneficiary",
+  "description": "Invalid lock request missing beneficiary",
+  "purpose": "Validates that Lock messages must include a beneficiary",
   "shouldPass": false,
   "version": "1.0.0",
   "taips": ["taip-2", "taip-17"],
   "message": {
     "id": "550e8400-e29b-41d4-a716-446655440001",
-    "type": "https://tap.rsvp/schema/1.0#Escrow",
+    "type": "https://tap.rsvp/schema/1.0#Lock",
     "from": "did:web:buyer.example",
     "to": ["did:web:escrow-service.example"],
     "created_time": 1709654400,
     "body": {
       "@context": "https://tap.rsvp/schema/1.0",
-      "@type": "https://tap.rsvp/schema/1.0#Escrow",
+      "@type": "https://tap.rsvp/schema/1.0#Lock",
       "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       "amount": "1000.00",
       "originator": {
@@ -36,7 +36,7 @@
     "valid": false,
     "error": {
       "type": "ValidationError",
-      "message": "Escrow message must include a beneficiary"
+      "message": "Lock message must include a beneficiary"
     }
   }
 }

--- a/test-vectors/lock/valid-lock.json
+++ b/test-vectors/lock/valid-lock.json
@@ -1,19 +1,19 @@
 {
-  "description": "Valid escrow request with conditions",
-  "purpose": "Validates an escrow message with release conditions and expiry",
+  "description": "Valid lock request with conditions",
+  "purpose": "Validates a Lock message with release conditions and expiry",
   "shouldPass": true,
   "version": "1.0.0",
   "taips": ["taip-2", "taip-17"],
   "message": {
     "id": "550e8400-e29b-41d4-a716-446655440000",
-    "type": "https://tap.rsvp/schema/1.0#Escrow",
+    "type": "https://tap.rsvp/schema/1.0#Lock",
     "from": "did:web:buyer.example",
     "to": ["did:web:escrow-service.example"],
     "created_time": 1709654400,
     "expires_time": 1709740800,
     "body": {
       "@context": "https://tap.rsvp/schema/1.0",
-      "@type": "https://tap.rsvp/schema/1.0#Escrow",
+      "@type": "https://tap.rsvp/schema/1.0#Lock",
       "asset": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       "amount": "1000.00",
       "originator": {

--- a/transactions.md
+++ b/transactions.md
@@ -4,7 +4,7 @@ title: TAP Transaction Types
 permalink: /transactions/
 ---
 
-The Transaction Authorization Protocol (TAP) supports four primary transaction message types: **Transfer**, **Payment**, **Exchange**, and **Escrow**. All enable compliant blockchain transactions, but they serve different business needs and workflows.
+The Transaction Authorization Protocol (TAP) supports four primary transaction message types: **Transfer**, **Payment**, **RFQ**, and **Lock**. All enable compliant blockchain transactions, but they serve different business needs and workflows.
 
 ## Transfer
 
@@ -48,9 +48,9 @@ The **Payment** message type extends TAP to support merchant payment scenarios w
 - **Invoice Support**: Includes comprehensive invoice functionality as defined in [TAIP-16](/TAIPs/taip-16.md), supporting detailed line items, tax information, and payment terms
 - **Policy Support**: Can include policy requirements (e.g., RequirePresentation) for customer information needed for the transaction
 
-## Exchange
+## RFQ
 
-The **Exchange** message type enables asset swaps and cross-asset quotations, facilitating conversion between different cryptocurrencies or between fiat and crypto assets.
+The **RFQ** (Request for Quote) message type enables asset swaps and cross-asset quotations, facilitating conversion between different cryptocurrencies or between fiat and crypto assets.
 
 ### Business Use Cases
 
@@ -62,16 +62,16 @@ The **Exchange** message type enables asset swaps and cross-asset quotations, fa
 
 ### Key Characteristics
 
-- **Quote-Based Model**: Uses a two-step process with Exchange request and Quote response
+- **Quote-Based Model**: Uses a two-step process with RFQ and Quote response
 - **Multi-Asset Support**: Handles arrays of source and target assets for flexible routing
 - **Rate Discovery**: Enables competitive pricing through multiple provider quotes
 - **Settlement Flexibility**: Can be combined with existing Authorize/Settle flows from [TAIP-4](/TAIPs/taip-4.md)
 - **Escrow Integration**: Can leverage escrow mechanisms from [TAIP-17](/TAIPs/taip-17.md) for counterparty risk management
 - **Provider Agnostic**: Supports both centralized liquidity providers and decentralized protocols
 
-## Escrow
+## Lock
 
-The **Escrow** message type enables third-party custody of assets with conditional release, providing security guarantees for complex transactions.
+The **Lock** message type enables third-party custody of assets with conditional release, providing security guarantees for complex transactions.
 
 ### Business Use Cases
 
@@ -94,7 +94,7 @@ The **Escrow** message type enables third-party custody of assets with condition
 
 ## Business Differences
 
-| Aspect | Transfer | Payment | Exchange | Escrow |
+| Aspect | Transfer | Payment | RFQ | Lock |
 |--------|----------|---------|----------|--------|
 | **Initiator** | Originator (sender) | Beneficiary (receiver) | Requester (either party) | Any party (typically beneficiary) |
 | **Flow Direction** | Push (send) | Pull (request) | Quote-based (negotiate) | Conditional hold (escrow) |
@@ -110,8 +110,8 @@ When implementing TAP, organizations should consider which transaction type best
 
 - **Financial Institutions** typically focus on the Transfer message type to support customer withdrawals and institutional transfers
 - **Merchants and Service Providers** benefit from implementing the Payment flow to collect payments
-- **Liquidity Providers and Exchanges** use the Exchange flow to offer asset conversion services
-- **Escrow Services and High-Value Transaction Facilitators** implement Escrow flows to provide security guarantees
+- **Liquidity Providers and Exchanges** use the RFQ flow to offer asset conversion services
+- **Escrow Services and High-Value Transaction Facilitators** implement Lock flows to provide security guarantees
 - **Full-Service Platforms** may implement all four to support various business scenarios including payments, transfers, asset exchanges, and conditional transactions
 
 For technical details on these message types, including required attributes and examples, see the [full message reference](/messages/#transaction-message).


### PR DESCRIPTION
## Summary

- Renames the TAIP-17 `Escrow` message type to `Lock` based on feedback from both payment and institutional users, who recognized `Lock` as the standard name for this pattern (lock + capture mirrors auth/capture in card payments)
- Preserves "Composable Escrow" as the TAIP title and the `EscrowAgent` role name; only the specific message identifier changed
- Also fixes stale `Exchange`→`RFQ` references in `transactions.md` that were missed when PR #56 landed
- Updates TAIP-17, TAIP-18 cross-references, `messages.md`, `transactions.md`, JSON schema (renamed `escrow.json` → `lock.json`), test vectors, the TypeScript SDK, and both CHANGELOGs

### Wire-format changes

| Before | After |
| --- | --- |
| `https://tap.rsvp/schema/1.0#Escrow` (DIDComm `type`) | `https://tap.rsvp/schema/1.0#Lock` |
| `@type: "Escrow"` (body) | `@type: "Lock"` |
| `schemas/messages/escrow.json` | `schemas/messages/lock.json` |
| `test-vectors/escrow/` | `test-vectors/lock/` |

### TypeScript SDK renames (rolled into the unreleased 2.0.0)

- `Escrow` → `Lock`
- `EscrowMessage` → `LockMessage`
- `EscrowSchema` → `LockSchema`
- `EscrowMessageSchema` → `LockMessageSchema`
- `validateEscrowMessage` → `validateLockMessage`
- `arbitraries.messageBodies.escrow` → `arbitraries.messageBodies.lock`
- `arbitraries.messages.escrowMessage` → `arbitraries.messages.lockMessage`

### What's intentionally preserved

- TAIP title: `Composable Escrow`
- Role identifier: `EscrowAgent` (the role describes the function the agent performs)
- Conceptual references to "escrow" as a workflow/activity throughout the spec text

## Test plan

- [x] `cd schemas && npm run validate` — schemas load cleanly (31 schemas)
- [x] `cd packages/typescript && npm run type-check` — passes
- [x] `cd packages/typescript && npm run test:run` — 144/144 tests pass
- [x] `cd packages/typescript && npm run build` — passes
- [ ] Reviewer to confirm we should keep `EscrowAgent` as the role name (vs renaming to `LockAgent`)
- [ ] Reviewer to confirm "Composable Escrow" is right to keep as the spec title

🤖 Generated with [Claude Code](https://claude.com/claude-code)