### PR TITLE
Apply TAP brand to Jekyll documentation site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,5 +34,11 @@ gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "webrick", "~> 1.8"
 
+# Jekyll 4.2.x relies on stdlib `logger` API that became incompatible
+# with Ruby 3.3+. Pinning the gem restores compatibility.
+gem "logger"
+gem "csv"
+gem "base64"
+
 # Markdown linter
 gem "mdl", "~> 0.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,12 @@ GEM
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.3.0)
     chef-utils (18.8.11)
       concurrent-ruby
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -47,6 +49,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mdl (0.11.0)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.1)
@@ -85,9 +88,12 @@ PLATFORMS
   arm64-darwin-24
 
 DEPENDENCIES
+  base64
+  csv
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.2.2)
   jekyll-feed (~> 0.12)
+  logger
   mdl (~> 0.11)
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,15 +26,8 @@
   </style>
   {%- feed_meta -%}
   
-  <script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({ 
-    startOnLoad: false,
-    });
-    await mermaid.run({
-      querySelector: 'pre code.language-mermaid',
-    });
-  </script>
+  <!-- Mermaid is initialized via /assets/js/mermaid-theme.js (loaded by the default layout). -->
+
 
   {%- if jekyll.environment == 'production' -%}
     <!-- Google tag (gtag.js) -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔄</text></svg>">
   <!-- Mermaid.js for diagrams -->
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script src="{{ '/assets/js/mermaid-theme.js' | relative_url }}" defer></script>
   
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-DFQHXTJQ91"></script>
@@ -23,7 +24,16 @@
   <div class="wrapper">
     <aside class="sidebar">
       <div class="header">
-        <a href="{{ '/' | relative_url }}" class="logo" style="font-size: 1.8rem; font-weight: 700;">TAP</a>
+        <a href="{{ '/' | relative_url }}" class="logo" aria-label="TAP — Transaction Authorization Protocol">
+          <svg width="28" height="28" viewBox="0 0 28 28" aria-hidden="true">
+            <rect x="2"    y="5" width="7" height="7" fill="#002F0D"/>
+            <rect x="10.5" y="5" width="7" height="7" fill="#00C2B8"/>
+            <rect x="19"   y="5" width="7" height="7" fill="#002F0D"/>
+            <path d="M5.5 16 L5.5 22 L22.5 22 L22.5 16" stroke="#002F0D" stroke-width="2" fill="none"/>
+            <circle cx="14" cy="22" r="2.5" fill="#00C2B8"/>
+          </svg>
+          <span class="logo-word">tap</span>
+        </a>
         <button class="mobile-menu-toggle" aria-label="Toggle mobile menu">☰</button>
       </div>
       
@@ -123,35 +133,5 @@
     });
   </script>
 
-  <!-- Initialize Mermaid diagrams -->
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      mermaid.initialize({
-        startOnLoad: true,
-        theme: 'default',
-        securityLevel: 'loose',
-        fontFamily: 'var(--font-sans)',
-        flowchart: {
-          curve: 'linear',
-          useMaxWidth: true
-        }
-      });
-      
-      // Process pre code blocks with language-mermaid class
-      document.querySelectorAll('pre code.language-mermaid').forEach(function(el) {
-        // Create a div for mermaid
-        const mermaidDiv = document.createElement('div');
-        mermaidDiv.className = 'mermaid';
-        mermaidDiv.innerHTML = el.textContent;
-        
-        // Replace the pre element with our mermaid div
-        const pre = el.parentElement;
-        pre.parentElement.replaceChild(mermaidDiv, pre);
-      });
-      
-      // Render mermaid
-      mermaid.init(undefined, document.querySelectorAll('.mermaid'));
-    });
-  </script>
 </body>
 </html>

--- a/_layouts/taip.html
+++ b/_layouts/taip.html
@@ -80,66 +80,70 @@ Process content to remove the copyright section
 
 <style>
   .taip-metadata {
-    background-color: var(--color-sidebar);
-    border-radius: 0.5rem;
-    padding: 1.25rem;
+    background-color: rgba(0,47,13,.02);
+    border: 1px solid var(--border-soft);
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
     margin-bottom: 2rem;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1rem;
-    border: 1px solid var(--color-border);
+    gap: 1rem 1.5rem;
   }
-  
+
   .metadata-item {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
+    font-size: 0.9375rem;
+    color: var(--tap-ink-2);
   }
-  
+
   .metadata-item strong {
-    font-weight: 600;
-    font-family: var(--font-heading);
+    font-weight: 700;
+    font-family: var(--font-sans);
+    color: var(--tap-ink);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 0.25rem;
   }
-  
-  .taip-content {
-    margin-top: 2rem;
-  }
-  
+
+  .taip-content { margin-top: 2rem; }
+
   .taip-content h2.hidden,
-  .taip-content h2.hidden + p {
-    display: none;
-  }
-  
+  .taip-content h2.hidden + p { display: none; }
+
   .toc {
-    background-color: var(--color-secondary-bg);
-    border-radius: 0.5rem;
-    padding: 1.25rem;
+    background-color: var(--tap-wash);
+    border: 1px solid var(--border-soft);
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
     margin-bottom: 2rem;
-    border: 1px solid var(--color-border);
   }
-  
+
   .toc h2 {
     margin-top: 0;
     border-bottom: none;
-    font-size: 1.25rem;
-    color: var(--color-secondary-fg);
-  }
-  
-  .toc ul {
-    margin-bottom: 0;
-  }
-  
-  .anchor-link {
-    color: var(--color-primary);
-    opacity: 0.5;
-    transition: opacity 0.2s;
-  }
-  
-  .anchor-link:hover {
-    opacity: 1;
+    font-size: 0.875rem;
+    font-family: var(--font-sans);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--tap-ink);
+    padding-bottom: 0;
   }
 
-  .license-section {
-    margin-top: 3rem;
+  .toc ul { margin-bottom: 0; }
+
+  .anchor-link {
+    color: var(--tap-accent);
+    opacity: 0.45;
+    transition: opacity 0.2s;
+    text-decoration: none;
   }
+
+  .anchor-link:hover { opacity: 1; }
+
+  .license-section { margin-top: 3rem; }
 </style>
 
 <h2>Citation</h2>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,33 +1,88 @@
-/* Main styling for TAP documentation site */
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Slab:wght@400;500;700&family=Fira+Code:wght@400;500;600;700&display=swap');
+/* ================================================================
+   TAP Documentation site — brand extension of Notabene tokens
+   Foundations: dark forest green (ink) on beige, with a teal-cyan
+   accent that signals authorization / TAP layer.
+   ================================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;500;600;700;800;900&family=Inter:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap');
 
 :root {
-  --color-primary: rgb(65, 224, 41);
-  --color-primary-light: rgba(65, 224, 41, 0.8);
-  --color-secondary-bg: hsl(111, 77%, 96%);
-  --color-secondary-fg: hsl(111, 77%, 30%);
-  --color-text: hsl(215, 25%, 27%);
-  --color-text-light: hsl(215, 25%, 40%);
-  --color-background: hsl(0, 0%, 100%);
-  --color-sidebar: hsl(0, 0%, 98%);
-  --color-border: hsl(214.3, 31.8%, 91.4%);
-  --color-code-bg: hsl(210, 38%, 95%);
-  --color-link: rgb(65, 224, 41);
-  --font-sans: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  /* ---- Notabene parent tokens ---- */
+  --nb-green:            #41E129;
+  --nb-green-electric:   #96F104;
+  --nb-green-base:       #ECF8E8;
+  --nb-green-complement: #C0EFCD;
+  --nb-green-dark:       #002F0D;
+  --nb-teal:             #7FEDE5;
+  --nb-beige:            #FAF8F2;
+  --nb-white:            #FFFFFF;
+  --nb-purple:           #C39AF9;
+  --nb-purple-link:      #8A38F5;
+  --nb-yellow:           #FFF599;
+
+  /* ---- TAP extensions ---- */
+  --tap-accent:          #00C2B8;   /* TAP cyan — authorization signal */
+  --tap-accent-2:        #7FEDE5;   /* soft cyan */
+  --tap-accent-soft:     #E6FBF9;   /* cyan wash on light */
+  --tap-accent-dark:     #00A89F;   /* hover cyan */
+  --tap-signal:          #41E129;   /* settlement = nb green */
+  --tap-purple:          #8A38F5;   /* reject/cancel rare accent */
+
+  /* Surfaces */
+  --tap-ink:             #002F0D;
+  --tap-ink-2:           rgba(0,47,13,.7);
+  --tap-ink-3:           rgba(0,47,13,.5);
+  --tap-ink-muted:       rgba(0,47,13,.4);
+  --tap-beige:           #FAF8F2;
+  --tap-wash:            #ECF8E8;
+  --tap-dark:            #002F0D;
+  --tap-night:           #001A07;
+  --border-soft:         rgba(0,47,13,.10);
+  --border-hairline:     rgba(0,0,0,.10);
+
+  /* Backwards-compat aliases used elsewhere in this stylesheet
+     and in inline page styles (index.html, taip.html). */
+  --color-primary:       var(--tap-accent);
+  --color-primary-light: var(--tap-accent-dark);
+  --color-secondary-bg:  var(--tap-wash);
+  --color-secondary-fg:  var(--tap-ink);
+  --color-text:          var(--tap-ink);
+  --color-text-light:    var(--tap-ink-2);
+  --color-background:    var(--tap-beige);
+  --color-sidebar:       var(--nb-white);
+  --color-border:        var(--border-soft);
+  --color-code-bg:       rgba(0,47,13,.04);
+  --color-link:          var(--tap-ink);
+
+  /* Fonts */
+  --font-sans:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
   --font-heading: 'Roboto Slab', Georgia, serif;
-  --font-mono: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-mono:    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+/* ================================================================
+   Base
+   ================================================================ */
+* { box-sizing: border-box; }
+
+html, body {
+  background: var(--tap-beige);
+  color: var(--tap-ink);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 body {
   font-family: var(--font-sans);
-  color: var(--color-text);
   margin: 0;
   padding: 0;
-  line-height: 1.6;
-  background-color: var(--color-background);
+  line-height: 1.55;
+  font-size: 16px;
 }
 
-/* Layout */
+/* ================================================================
+   Layout
+   ================================================================ */
 .wrapper {
   display: flex;
   min-height: 100vh;
@@ -35,8 +90,8 @@ body {
 
 .sidebar {
   width: 280px;
-  background-color: var(--color-sidebar);
-  border-right: 1px solid var(--color-border);
+  background-color: var(--nb-white);
+  border-right: 1px solid var(--border-soft);
   position: fixed;
   height: 100vh;
   overflow-y: auto;
@@ -46,39 +101,72 @@ body {
 .main-content {
   flex-grow: 1;
   margin-left: 280px;
-  padding: 2rem;
-  max-width: 860px;
+  padding: 2.5rem 3rem;
+  max-width: 920px;
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid var(--color-border);
+  padding: 1.5rem 1.5rem 1.25rem;
+  border-bottom: 1px solid var(--border-soft);
 }
 
+/* ================================================================
+   TAP wordmark in the sidebar
+   ================================================================ */
 .logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   font-family: var(--font-heading);
   font-weight: 700;
-  font-size: 1.25rem;
-  color: var(--color-primary);
+  font-size: 22px;
+  letter-spacing: -0.04em;
+  color: var(--tap-ink);
   text-decoration: none;
+  line-height: 1;
 }
 
-/* Navigation */
-.nav-section {
-  margin-bottom: 1.5rem;
+.logo:hover {
+  text-decoration: none;
+  opacity: .85;
 }
+
+.logo svg { display: block; }
+
+.logo-word {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--tap-ink);
+}
+
+/* ================================================================
+   Navigation
+   ================================================================ */
+.nav-section { margin-bottom: 1.5rem; }
 
 .nav-section-title {
-  padding: 0.75rem 1.5rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-primary);
+  padding: 0.75rem 1.5rem 0.5rem;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--tap-ink);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-family: var(--font-heading);
+  letter-spacing: 0.12em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-section-title::before {
+  content: "";
+  display: inline-block;
+  width: 14px;
+  height: 2px;
+  background: var(--tap-accent);
 }
 
 .nav-links {
@@ -89,21 +177,25 @@ body {
 
 .nav-link {
   display: block;
-  padding: 0.5rem 1.5rem;
-  color: var(--color-text);
+  padding: 0.45rem 1.5rem 0.45rem 2.1rem;
+  color: var(--tap-ink-2);
   text-decoration: none;
-  font-size: 0.9375rem;
-  transition: background-color 0.2s;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  transition: color .18s ease, background-color .18s ease;
+  position: relative;
 }
 
 .nav-link:hover {
-  background-color: rgba(65, 224, 41, 0.05);
+  color: var(--tap-ink);
+  text-decoration: none;
+  background-color: rgba(0,47,13,.03);
 }
 
 .nav-link.active {
-  color: var(--color-primary);
-  font-weight: 500;
-  position: relative;
+  color: var(--tap-ink);
+  font-weight: 600;
+  background-color: var(--tap-accent-soft);
 }
 
 .nav-link.active::before {
@@ -113,183 +205,245 @@ body {
   top: 0;
   bottom: 0;
   width: 3px;
-  background-color: var(--color-primary);
+  background-color: var(--tap-accent);
 }
 
-/* Sidebar CTA */
+/* TAIP entries in the sidebar — set in mono, since they're protocol identifiers */
+.nav-section:last-of-type .nav-link {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  letter-spacing: -0.01em;
+}
+
+/* ================================================================
+   Sidebar CTA
+   ================================================================ */
 .sidebar-cta {
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--color-border);
+  padding: 1rem 1.5rem 1.25rem;
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .whitepaper-cta {
   display: block;
   width: 100%;
   padding: 0.75rem 1rem;
-  background-color: var(--color-primary);
-  color: white;
+  background-color: var(--tap-ink);
+  color: var(--nb-white);
   text-decoration: none;
-  border-radius: 0.375rem;
+  border-radius: 10px;
   font-family: var(--font-heading);
-  font-weight: 500;
+  font-weight: 700;
   font-size: 0.9rem;
+  letter-spacing: -0.02em;
   text-align: center;
-  transition: background-color 0.2s, transform 0.2s;
+  transition: background-color .18s ease, transform .18s ease;
   box-sizing: border-box;
 }
 
 .whitepaper-cta:hover {
-  background-color: var(--color-primary-light);
-  color: white;
-  transform: translateY(-2px);
+  background-color: var(--tap-night);
+  color: var(--nb-white);
+  text-decoration: none;
+  transform: translateY(-1px);
 }
 
-/* Typography */
+/* ================================================================
+   Typography
+   ================================================================ */
 h1, h2, h3, h4, h5, h6 {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-  font-weight: 600;
-  line-height: 1.25;
-  color: var(--color-text);
   font-family: var(--font-heading);
+  color: var(--tap-ink);
+  font-weight: 500;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+  margin-top: 2.25rem;
+  margin-bottom: 1rem;
 }
 
 h1 {
-  font-size: 2.25rem;
-  font-weight: 700;
+  font-size: 2.5rem;
+  font-weight: 500;
   margin-top: 0;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
+  letter-spacing: -0.035em;
 }
 
 h2 {
-  font-size: 1.5rem;
+  font-size: 1.75rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-soft);
+  letter-spacing: -0.03em;
 }
 
 h3 {
-  font-size: 1.25rem;
+  font-size: 1.375rem;
 }
 
-a {
-  color: var(--color-link);
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
+h4 {
+  font-size: 1.125rem;
 }
 
 p {
   margin-top: 0;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.1rem;
+  color: var(--tap-ink-2);
 }
 
-/* Code blocks */
-pre {
-  background-color: var(--color-code-bg);
-  border-radius: 0.375rem;
-  padding: 1rem;
-  overflow: auto;
-  font-size: 0.875rem;
-  margin: 1.5rem 0;
+a {
+  color: var(--tap-ink);
+  text-decoration: underline;
+  text-decoration-color: var(--tap-accent);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: opacity .18s ease;
 }
 
+a:hover {
+  opacity: .7;
+  text-decoration-color: var(--tap-accent);
+}
+
+strong { color: var(--tap-ink); }
+
+/* ================================================================
+   Code blocks
+   ================================================================ */
 code {
   font-family: var(--font-mono);
-  font-size: 0.875em;
-  background-color: var(--color-code-bg);
-  padding: 0.2em 0.4em;
-  border-radius: 0.25em;
+  font-size: 0.85em;
+  background-color: rgba(0,47,13,.05);
+  color: var(--tap-ink);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+pre {
+  background-color: var(--nb-white);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 16px 18px;
+  overflow: auto;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 1.5rem 0;
 }
 
 pre code {
   background-color: transparent;
   padding: 0;
   border-radius: 0;
+  font-size: 13px;
+  color: var(--tap-ink);
+  display: block;
+  line-height: 1.55;
 }
 
-/* Tables */
+pre.highlight {
+  background-color: var(--nb-white);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 16px 18px;
+  font-size: 13px;
+  margin: 0;
+}
+
+div.highlight {
+  overflow: auto;
+  padding: 0;
+  margin: 1.25rem 0;
+}
+
+.language-json { line-height: 1.55; }
+
+/* ================================================================
+   Tables
+   ================================================================ */
 table {
   width: 100%;
   border-collapse: collapse;
   margin: 1.5rem 0;
   font-size: 0.9375rem;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 th {
-  background-color: var(--color-sidebar);
+  background-color: var(--tap-wash);
   text-align: left;
   padding: 0.75rem 1rem;
   font-weight: 600;
-  border-bottom: 1px solid var(--color-border);
+  font-family: var(--font-sans);
+  color: var(--tap-ink);
+  border-bottom: 1px solid var(--border-soft);
 }
 
 td {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--tap-ink-2);
 }
 
-/* Footer */
+tr:last-child td { border-bottom: none; }
+
+/* ================================================================
+   Footer
+   ================================================================ */
 footer {
   margin-top: 4rem;
   padding-top: 2rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-soft);
   font-size: 0.875rem;
-  color: var(--color-text-light);
+  color: var(--tap-ink-3);
 }
 
-/* Attribution styling */
 .attribution {
   margin-top: 1.5rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-soft);
   font-size: 0.875rem;
-  color: var(--color-text-light);
+  color: var(--tap-ink-3);
   text-align: center;
 }
 
 .attribution a {
-  color: var(--color-primary);
+  color: var(--tap-ink);
   font-weight: 500;
+  text-decoration-color: var(--tap-accent);
 }
 
-.attribution a:hover {
-  text-decoration: underline;
-}
-
-/* Responsive design */
+/* ================================================================
+   Responsive
+   ================================================================ */
 @media (max-width: 768px) {
-  .wrapper {
-    flex-direction: column;
-  }
-  
+  .wrapper { flex-direction: column; }
+
   .sidebar {
     width: 100%;
     height: auto;
     position: static;
     border-right: none;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--border-soft);
     max-height: 60px;
     overflow: hidden;
     transition: max-height 0.3s ease;
   }
-  
+
   .sidebar.expanded {
     max-height: 100vh;
     overflow-y: auto;
   }
-  
+
   .main-content {
     margin-left: 0;
     padding: 1.5rem;
   }
-  
+
   .header {
     padding: 1rem 1.5rem;
     position: relative;
   }
-  
+
   .mobile-menu-toggle {
     display: block;
     position: absolute;
@@ -298,7 +452,7 @@ footer {
     transform: translateY(-50%);
     background: none;
     border: none;
-    color: var(--color-primary);
+    color: var(--tap-ink);
     font-size: 1.5rem;
     cursor: pointer;
     width: 30px;
@@ -306,12 +460,13 @@ footer {
     padding: 0;
     z-index: 10;
   }
-  
+
   .nav-section-title {
     cursor: pointer;
     position: relative;
+    padding-right: 2.5rem;
   }
-  
+
   .nav-section-title::after {
     content: "+";
     position: absolute;
@@ -319,134 +474,184 @@ footer {
     top: 50%;
     transform: translateY(-50%);
     transition: transform 0.2s;
+    color: var(--tap-ink-3);
   }
-  
-  .nav-section.expanded .nav-section-title::after {
-    content: "−";
-  }
-  
+
+  .nav-section.expanded .nav-section-title::after { content: "−"; }
+
   .nav-links {
     max-height: 0;
     overflow: hidden;
     transition: max-height 0.3s ease;
   }
-  
-  .nav-section.expanded .nav-links {
-    max-height: 1000px;
-  }
-  
-  .nav-link {
-    padding: 0.75rem 1.5rem;
-  }
+
+  .nav-section.expanded .nav-links { max-height: 1500px; }
+  .nav-link { padding: 0.65rem 1.5rem 0.65rem 2.1rem; }
 }
 
 @media (min-width: 769px) {
-  .mobile-menu-toggle {
-    display: none;
-  }
-  
-  .nav-links {
-    max-height: none !important;
-  }
+  .mobile-menu-toggle { display: none; }
+  .nav-links { max-height: none !important; }
 }
 
-/* Buttons */
+/* ================================================================
+   Buttons
+   ================================================================ */
 .button {
-  font-family: var(--font-heading);
-  font-weight: 500;
-}
-
-/* Special elements */
-.status-pill {
   display: inline-block;
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  padding: 14px 24px;
+  border-radius: 10px;
+  background-color: var(--tap-ink);
+  color: var(--nb-white);
   font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+  text-align: center;
+  transition: background-color .18s ease, transform .18s ease;
+  border: none;
+  cursor: pointer;
 }
 
-.status-final {
-  background-color: var(--color-secondary-bg);
-  color: var(--color-secondary-fg);
-}
-
-.status-last-call {
-  background-color: #dbeafe;
-  color: #1e40af;
-}
-
-.status-review {
-  background-color: #ffedd5;
-  color: #9a3412;
-}
-
-.status-draft {
-  background-color: #e0f2fe;
-  color: #0369a1;
-}
-
-/* Discussion links */
-.metadata-item a {
-  display: inline-block;
-  padding: 0.2rem 0.5rem;
-  margin: 0 0.1rem;
-  background-color: var(--color-secondary-bg);
-  color: var(--color-secondary-fg);
-  border-radius: 0.25rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: background-color 0.2s, transform 0.2s;
-}
-
-.metadata-item a:hover {
-  background-color: var(--color-primary-light);
-  color: var(--color-text);
+.button:hover {
+  background-color: var(--tap-night);
+  color: var(--nb-white);
   text-decoration: none;
   transform: translateY(-1px);
 }
 
-/* Add a small external link icon */
+.button-secondary {
+  background-color: transparent;
+  color: var(--tap-ink);
+  border: 1px solid var(--tap-ink);
+}
+
+.button-secondary:hover {
+  background-color: rgba(0,47,13,.05);
+  color: var(--tap-ink);
+  opacity: 1;
+}
+
+/* ================================================================
+   Status pills
+   ================================================================ */
+.status-pill {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--font-mono);
+}
+
+.status-final {
+  background-color: rgba(65,225,41,.12);
+  color: #1B7A12;
+}
+
+.status-last-call {
+  background-color: var(--tap-accent-soft);
+  color: var(--tap-accent-dark);
+}
+
+.status-review {
+  background-color: var(--tap-wash);
+  color: var(--tap-ink);
+}
+
+.status-draft {
+  background-color: rgba(195,154,249,.18);
+  color: var(--nb-purple-link);
+}
+
+/* ================================================================
+   Discussion / metadata links
+   ================================================================ */
+.metadata-item a {
+  display: inline-block;
+  padding: 3px 8px;
+  margin: 0 0.1rem;
+  background-color: var(--tap-wash);
+  color: var(--tap-ink);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  text-decoration: none;
+  transition: background-color .18s ease, transform .18s ease;
+}
+
+.metadata-item a:hover {
+  background-color: var(--tap-accent-soft);
+  color: var(--tap-ink);
+  text-decoration: none;
+  transform: translateY(-1px);
+  opacity: 1;
+}
+
 .metadata-item a::after {
   content: "↗";
   display: inline-block;
   margin-left: 0.25rem;
   font-size: 0.75rem;
   vertical-align: super;
+  color: var(--tap-accent-dark);
 }
 
-/* Table of Contents */
+/* ================================================================
+   Table of contents
+   ================================================================ */
 .toc h2 {
   margin-top: 0;
   border-bottom: none;
-  font-size: 1.25rem;
-  color: var(--color-primary);
+  font-size: 1.125rem;
+  color: var(--tap-ink);
+  font-family: var(--font-sans);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding-bottom: 0;
 }
 
-.toc ul {
-  margin-bottom: 0;
+.toc h2::before {
+  content: "";
+  display: inline-block;
+  width: 18px;
+  height: 2px;
+  background: var(--tap-accent);
+  margin-right: 8px;
+  vertical-align: middle;
 }
+
+.toc ul { margin-bottom: 0; }
 
 .toc ul li a {
-  color: var(--color-text);
-  transition: color 0.2s;
-}
-
-.toc ul li a:hover {
-  color: var(--color-primary);
+  color: var(--tap-ink-2);
+  transition: color .18s ease, opacity .18s ease;
   text-decoration: none;
 }
 
-/* Mermaid diagrams */
+.toc ul li a:hover {
+  color: var(--tap-ink);
+  text-decoration: underline;
+  text-decoration-color: var(--tap-accent);
+}
+
+/* ================================================================
+   Mermaid diagrams — container only.
+   SVG-internal styling lives in /assets/js/mermaid-theme.js so the
+   Notabene/TAP look applies as soon as mermaid renders.
+   ================================================================ */
 .mermaid {
-  background-color: var(--color-secondary-bg);
-  padding: 1.5rem;
-  margin: 1.5rem 0;
-  border-radius: 0.5rem;
+  background-color: var(--nb-white);
+  padding: 1.75rem 1.5rem;
+  margin: 1.75rem 0;
+  border-radius: 10px;
   text-align: center;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-soft);
   overflow-x: auto;
 }
 
@@ -455,152 +660,80 @@ footer {
   height: auto !important;
 }
 
-/* Make sure the primary diagram colors match our theme */
-.mermaid .label {
-  font-family: var(--font-sans);
-  color: var(--color-text) !important;
-}
-
-.mermaid .node rect, 
-.mermaid .node circle, 
-.mermaid .node ellipse, 
-.mermaid .node polygon, 
-.mermaid .node path {
-  fill: var(--color-secondary-bg) !important;
-  stroke: var(--color-primary) !important;
-}
-
-.mermaid .edgePath .path {
-  stroke: var(--color-primary) !important;
-}
-
-.mermaid .flowchart-link {
-  stroke: var(--color-primary) !important;
-}
-
-/* Syntax highlighting styles */
+/* ================================================================
+   Syntax highlighting (Rouge)
+   ================================================================ */
 .highlight .hll { background-color: #ffffcc }
-.highlight .c { color: #888888; font-style: italic } /* Comment */
-.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight .k { color: #008800; font-weight: bold } /* Keyword */
-.highlight .cm { color: #888888; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #cc0000; font-weight: bold } /* Comment.Preproc */
-.highlight .c1 { color: #888888; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #cc0000; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #aa0000 } /* Generic.Error */
-.highlight .gh { color: #333333 } /* Generic.Heading */
-.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight .go { color: #888888 } /* Generic.Output */
-.highlight .gp { color: #555555 } /* Generic.Prompt */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #666666 } /* Generic.Subheading */
-.highlight .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight .kc { color: #008800; font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: #008800; font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: #008800; font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: #008800 } /* Keyword.Pseudo */
-.highlight .kr { color: #008800; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #888888; font-weight: bold } /* Keyword.Type */
-.highlight .m { color: #0000DD; font-weight: bold } /* Literal.Number */
-.highlight .s { color: #dd2200 } /* Literal.String */
-.highlight .na { color: #336699 } /* Name.Attribute */
-.highlight .nb { color: #003388 } /* Name.Builtin */
-.highlight .nc { color: #bb0066; font-weight: bold } /* Name.Class */
-.highlight .no { color: #003366; font-weight: bold } /* Name.Constant */
-.highlight .nd { color: #555555 } /* Name.Decorator */
-.highlight .ne { color: #bb0066; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #0066bb; font-weight: bold } /* Name.Function */
-.highlight .nl { color: #336699; font-style: italic } /* Name.Label */
-.highlight .nn { color: #bb0066; font-weight: bold } /* Name.Namespace */
-.highlight .py { color: #336699; font-weight: bold } /* Name.Property */
-.highlight .nt { color: #bb0066; font-weight: bold } /* Name.Tag */
-.highlight .nv { color: #336699 } /* Name.Variable */
-.highlight .ow { color: #008800 } /* Operator.Word */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mf { color: #0000DD; font-weight: bold } /* Literal.Number.Float */
-.highlight .mh { color: #0000DD; font-weight: bold } /* Literal.Number.Hex */
-.highlight .mi { color: #0000DD; font-weight: bold } /* Literal.Number.Integer */
-.highlight .mo { color: #0000DD; font-weight: bold } /* Literal.Number.Oct */
-.highlight .sb { color: #dd2200 } /* Literal.String.Backtick */
-.highlight .sc { color: #dd2200 } /* Literal.String.Char */
-.highlight .sd { color: #dd2200; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #dd2200 } /* Literal.String.Double */
-.highlight .se { color: #0044dd } /* Literal.String.Escape */
-.highlight .sh { color: #dd2200 } /* Literal.String.Heredoc */
-.highlight .si { color: #3333bb } /* Literal.String.Interpol */
-.highlight .sx { color: #22bb22 } /* Literal.String.Other */
-.highlight .sr { color: #008800 } /* Literal.String.Regex */
-.highlight .s1 { color: #dd2200 } /* Literal.String.Single */
-.highlight .ss { color: #aa6600 } /* Literal.String.Symbol */
-.highlight .bp { color: #003388 } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #336699 } /* Name.Variable.Class */
-.highlight .vg { color: #dd7700 } /* Name.Variable.Global */
-.highlight .vi { color: #3333bb } /* Name.Variable.Instance */
-.highlight .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight .c  { color: rgba(0,47,13,.45); font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 }
+.highlight .k  { color: var(--tap-accent-dark); font-weight: 600 } /* Keyword */
+.highlight .cm { color: rgba(0,47,13,.45); font-style: italic }
+.highlight .cp { color: var(--tap-accent-dark); font-weight: 600 }
+.highlight .c1 { color: rgba(0,47,13,.45); font-style: italic }
+.highlight .cs { color: var(--tap-accent-dark); font-weight: 600; font-style: italic }
+.highlight .gd { color: #000; background-color: #ffdddd }
+.highlight .ge { font-style: italic }
+.highlight .gr { color: #aa0000 }
+.highlight .gh { color: var(--tap-ink) }
+.highlight .gi { color: #000; background-color: #ddffdd }
+.highlight .go { color: rgba(0,47,13,.5) }
+.highlight .gp { color: rgba(0,47,13,.7) }
+.highlight .gs { font-weight: 600 }
+.highlight .gu { color: rgba(0,47,13,.6) }
+.highlight .gt { color: #aa0000 }
+.highlight .kc { color: #A15B00; font-weight: 600 }
+.highlight .kd { color: var(--tap-accent-dark); font-weight: 600 }
+.highlight .kn { color: var(--tap-accent-dark); font-weight: 600 }
+.highlight .kp { color: var(--tap-accent-dark) }
+.highlight .kr { color: var(--tap-accent-dark); font-weight: 600 }
+.highlight .kt { color: var(--tap-ink-2); font-weight: 600 }
+.highlight .m  { color: #A15B00; font-weight: 600 }
+.highlight .s  { color: #0E7A42 }
+.highlight .na { color: var(--tap-accent-dark) }
+.highlight .nb { color: var(--tap-accent-dark) }
+.highlight .nc { color: var(--nb-purple-link); font-weight: 600 }
+.highlight .no { color: var(--tap-ink); font-weight: 600 }
+.highlight .nd { color: var(--tap-ink-2) }
+.highlight .ne { color: var(--nb-purple-link); font-weight: 600 }
+.highlight .nf { color: var(--tap-accent-dark); font-weight: 600 }
+.highlight .nl { color: var(--tap-accent-dark); font-style: italic }
+.highlight .nn { color: var(--nb-purple-link); font-weight: 600 }
+.highlight .py { color: var(--tap-accent-dark); font-weight: 600 }
+.highlight .nt { color: var(--nb-purple-link); font-weight: 600 }
+.highlight .nv { color: var(--tap-accent-dark) }
+.highlight .ow { color: var(--tap-accent-dark) }
+.highlight .w  { color: #bbbbbb }
+.highlight .mf { color: #A15B00; font-weight: 600 }
+.highlight .mh { color: #A15B00; font-weight: 600 }
+.highlight .mi { color: #A15B00; font-weight: 600 }
+.highlight .mo { color: #A15B00; font-weight: 600 }
+.highlight .sb { color: #0E7A42 }
+.highlight .sc { color: #0E7A42 }
+.highlight .sd { color: #0E7A42; font-style: italic }
+.highlight .s2 { color: #0E7A42 }
+.highlight .se { color: #0044dd }
+.highlight .sh { color: #0E7A42 }
+.highlight .si { color: #3333bb }
+.highlight .sx { color: #22bb22 }
+.highlight .sr { color: var(--tap-accent-dark) }
+.highlight .s1 { color: #0E7A42 }
+.highlight .ss { color: #A15B00 }
+.highlight .bp { color: var(--tap-accent-dark) }
+.highlight .vc { color: var(--tap-accent-dark) }
+.highlight .vg { color: #A15B00 }
+.highlight .vi { color: #3333bb }
+.highlight .il { color: #A15B00; font-weight: 600 }
 
-/* Specific styles for JSON syntax highlighting */
-.language-json .highlight .p { color: #666666 } /* Punctuation */
-.language-json .highlight .s2 { color: #008800 } /* String - use primary green */
+/* JSON-specific overrides */
+.language-json .highlight .p  { color: var(--tap-ink-3) }
+.language-json .highlight .s2 { color: #0E7A42 }
 .language-json .highlight .mi,
-.language-json .highlight .mf { color: #0066bb } /* Numbers */
-.language-json .highlight .kc { color: #aa6600 } /* true, false, null */
-.language-json .highlight .err { color: inherit; background-color: inherit; } /* No error styling in JSON */
+.language-json .highlight .mf { color: #A15B00 }
+.language-json .highlight .kc { color: #A15B00 }
+.language-json .highlight .err { color: inherit; background-color: inherit; }
 
-/* Improve code block readability */
-pre.highlight {
-  background-color: var(--color-code-bg);
-  border-radius: 0.375rem;
-  padding: 1rem;
-  overflow: auto;
-  font-size: 1rem;
-  margin: 0;
-  border: 1px solid var(--color-border);
-}
-
-div.highlight {
-  overflow: auto;
-  padding: 0;
-  margin: 0;
-}
-
-pre code {
-  display: block;
-  line-height: 1.4;
-}
-
-/* Override default line height for code blocks */
-.language-json {
-  line-height: 1.4;
-}
-
-/* Tables */
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 1.5rem 0;
-  font-size: 0.9375rem;
-}
-
-th {
-  background-color: var(--color-sidebar);
-  text-align: left;
-  padding: 0.75rem 1rem;
-  font-weight: 600;
-  border-bottom: 1px solid var(--color-border);
-}
-
-td {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--color-border);
-}
-
-/* Examples section styling */
-.examples pre.highlight {
-  margin: 0.5rem 0;
-}
-
-.examples h2 {
-  margin-bottom: 0.5rem;
-} 
+/* ================================================================
+   Examples section
+   ================================================================ */
+.examples pre.highlight { margin: 0.5rem 0; }
+.examples h2 { margin-bottom: 0.5rem; }

--- a/assets/js/mermaid-theme.js
+++ b/assets/js/mermaid-theme.js
@@ -1,0 +1,289 @@
+/* ================================================================
+   TAP Mermaid theme — Notabene foundation + TAP cyan accents.
+   Adapted from the notabene-branding skill (`ui_kits/docs/mermaid-theme.js`).
+
+   Initialize *before* mermaid auto-runs, then manually parse each block
+   so we don't race the default `startOnLoad` pipeline.
+   ================================================================ */
+(function () {
+  const THEME = {
+    darkGreen: '#002F0D',  /* TAP ink */
+    green:     '#41E129',  /* settlement / success */
+    greenBase: '#ECF8E8',  /* tap-wash */
+    greenComp: '#C0EFCD',
+    teal:      '#7FEDE5',  /* tap-accent-2 */
+    cyan:      '#00C2B8',  /* tap-accent — TAP authorization signal */
+    cyanSoft:  '#E6FBF9',
+    beige:     '#FAF8F2',
+    grey:      '#808080',
+    border:    '#949494',
+  };
+
+  const cfg = {
+    startOnLoad: false,
+    theme: 'base',
+    fontFamily: "'Roboto Slab', Georgia, serif",
+    securityLevel: 'loose',
+    themeVariables: {
+      primaryColor:        '#FFFFFF',
+      primaryTextColor:    THEME.darkGreen,
+      primaryBorderColor:  THEME.darkGreen,
+      secondaryColor:      THEME.greenBase,
+      secondaryTextColor:  THEME.darkGreen,
+      secondaryBorderColor: THEME.darkGreen,
+      tertiaryColor:       THEME.beige,
+      tertiaryTextColor:   THEME.darkGreen,
+      tertiaryBorderColor: THEME.darkGreen,
+
+      background:          THEME.beige,
+      mainBkg:             '#FFFFFF',
+      secondBkg:           THEME.greenBase,
+      lineColor:           THEME.darkGreen,
+      textColor:           THEME.darkGreen,
+
+      /* Flowchart */
+      nodeBorder:          THEME.darkGreen,
+      clusterBkg:          THEME.beige,
+      clusterBorder:       THEME.darkGreen,
+      defaultLinkColor:    THEME.darkGreen,
+      titleColor:          THEME.darkGreen,
+      edgeLabelBackground: THEME.beige,
+      nodeTextColor:       THEME.darkGreen,
+
+      /* Sequence */
+      actorBkg:            THEME.darkGreen,
+      actorTextColor:      '#FFFFFF',
+      actorBorder:         THEME.darkGreen,
+      actorLineColor:      THEME.grey,
+      signalColor:         THEME.darkGreen,
+      signalTextColor:     THEME.darkGreen,
+      labelBoxBkgColor:    '#FFFFFF',
+      labelBoxBorderColor: THEME.darkGreen,
+      labelTextColor:      THEME.darkGreen,
+      loopTextColor:       THEME.darkGreen,
+      noteBkgColor:        THEME.greenBase,
+      noteBorderColor:     THEME.darkGreen,
+      noteTextColor:       THEME.darkGreen,
+      /* TAP twist: activation rectangles in cyan = authorization "in flight". */
+      activationBkgColor:  THEME.cyanSoft,
+      activationBorderColor: THEME.cyan,
+      sequenceNumberColor: '#FFFFFF',
+
+      /* State */
+      specialStateColor:   THEME.green,
+      innerEndBackground:  THEME.darkGreen,
+      altBackground:       THEME.beige,
+
+      errorBkgColor:       '#FFE8E8',
+      errorTextColor:      '#8A1B1B',
+    },
+    flowchart: { curve: 'linear', nodeSpacing: 50, rankSpacing: 60, htmlLabels: true, useMaxWidth: true },
+    sequence: { actorMargin: 80, messageMargin: 46, mirrorActors: false, showSequenceNumbers: false, useMaxWidth: true },
+    state:    { nodeSpacing: 50, useMaxWidth: true },
+  };
+
+  function injectStyles() {
+    if (document.getElementById('__tap_mermaid_styles')) return;
+    const s = document.createElement('style');
+    s.id = '__tap_mermaid_styles';
+    s.textContent = `
+      .mermaid svg { background: transparent; }
+
+      /* --- Flowchart node shapes --- */
+      .mermaid .node > rect, .mermaid .node > polygon, .mermaid .node > circle,
+      .mermaid .node > ellipse, .mermaid .node > path {
+        stroke-width: 1.5px !important;
+        filter: drop-shadow(3px 3px 0 rgba(0,0,0,.12));
+      }
+      .mermaid .node:not(.solid):not(.lime):not(.soft):not(.cyan) > rect,
+      .mermaid .node:not(.solid):not(.lime):not(.soft):not(.cyan) > polygon,
+      .mermaid .node:not(.solid):not(.lime):not(.soft):not(.cyan) > path {
+        fill: #FFFFFF !important; stroke: ${THEME.darkGreen} !important;
+      }
+
+      /* classDef variants — usable from inside a diagram via \`class X solid\` etc. */
+      .mermaid .node.solid > rect, .mermaid .node.solid > polygon, .mermaid .node.solid > path, .mermaid .node.solid > ellipse {
+        fill: ${THEME.darkGreen} !important; stroke: ${THEME.darkGreen} !important;
+      }
+      .mermaid .node.solid .nodeLabel, .mermaid .node.solid .label, .mermaid .node.solid foreignObject * {
+        color: #FFFFFF !important; fill: #FFFFFF !important;
+      }
+      .mermaid .node.lime > rect, .mermaid .node.lime > polygon, .mermaid .node.lime > path {
+        fill: ${THEME.green} !important; stroke: ${THEME.darkGreen} !important;
+      }
+      .mermaid .node.lime .nodeLabel, .mermaid .node.lime .label, .mermaid .node.lime foreignObject * {
+        color: ${THEME.darkGreen} !important; fill: ${THEME.darkGreen} !important;
+      }
+      .mermaid .node.soft > rect, .mermaid .node.soft > polygon, .mermaid .node.soft > path {
+        fill: ${THEME.greenBase} !important; stroke: ${THEME.darkGreen} !important;
+      }
+      .mermaid .node.soft .nodeLabel, .mermaid .node.soft .label, .mermaid .node.soft foreignObject * {
+        color: ${THEME.darkGreen} !important; fill: ${THEME.darkGreen} !important;
+      }
+      /* TAP cyan variant — for authorization-layer / TAP message nodes. */
+      .mermaid .node.cyan > rect, .mermaid .node.cyan > polygon, .mermaid .node.cyan > path {
+        fill: ${THEME.cyanSoft} !important; stroke: ${THEME.cyan} !important;
+      }
+      .mermaid .node.cyan .nodeLabel, .mermaid .node.cyan .label, .mermaid .node.cyan foreignObject * {
+        color: ${THEME.darkGreen} !important; fill: ${THEME.darkGreen} !important;
+      }
+
+      /* Node labels — slab serif, dark ink. */
+      .mermaid .nodeLabel, .mermaid .node .label, .mermaid .node foreignObject div {
+        font-family: 'Roboto Slab', Georgia, serif !important;
+        font-size: 14px !important;
+        letter-spacing: -.02em !important;
+        color: ${THEME.darkGreen};
+      }
+
+      /* Cluster (subgraph) framing — TAP layered architecture vibe. */
+      .mermaid .cluster rect {
+        fill: ${THEME.beige} !important;
+        stroke: ${THEME.darkGreen} !important;
+        stroke-dasharray: 4 4 !important;
+        stroke-width: 1px !important;
+      }
+      .mermaid .cluster .cluster-label,
+      .mermaid .cluster .nodeLabel {
+        font-family: 'Inter', sans-serif !important;
+        font-weight: 700 !important;
+        font-size: 11px !important;
+        letter-spacing: 0.12em !important;
+        text-transform: uppercase !important;
+        color: ${THEME.darkGreen} !important;
+        fill: ${THEME.darkGreen} !important;
+      }
+
+      /* Edge labels — mono, beige pill. */
+      .mermaid .edgeLabel, .mermaid .edgeLabel p, .mermaid .edgeLabel span {
+        font-family: 'Geist Mono', ui-monospace, monospace !important;
+        font-size: 12px !important;
+        letter-spacing: 0.02em !important;
+        color: ${THEME.darkGreen} !important;
+        background: ${THEME.beige} !important;
+        padding: 2px 6px !important;
+      }
+      .mermaid .edgeLabel rect { fill: ${THEME.beige} !important; stroke: ${THEME.border} !important; }
+      .mermaid .edgePath .path, .mermaid .flowchart-link {
+        stroke: ${THEME.darkGreen} !important; stroke-width: 1.5px !important;
+      }
+      .mermaid .marker, .mermaid defs marker path {
+        fill: ${THEME.darkGreen} !important; stroke: ${THEME.darkGreen} !important;
+      }
+
+      /* --- Sequence diagram --- */
+      .mermaid .actor {
+        fill: ${THEME.darkGreen} !important;
+        stroke: ${THEME.darkGreen} !important;
+        filter: drop-shadow(3px 3px 0 rgba(0,0,0,.12));
+      }
+      .mermaid text.actor, .mermaid text.actor > tspan {
+        fill: #FFFFFF !important;
+        font-family: 'Roboto Slab', Georgia, serif !important;
+        font-weight: 500 !important;
+        font-size: 14px !important;
+      }
+      .mermaid .actor-line {
+        stroke: ${THEME.grey} !important;
+        stroke-dasharray: 4 3 !important;
+        opacity: .6;
+      }
+      .mermaid .messageLine0, .mermaid .messageLine1 {
+        stroke: ${THEME.darkGreen} !important;
+        stroke-width: 1.5px !important;
+      }
+      .mermaid .messageText {
+        fill: ${THEME.darkGreen} !important;
+        font-family: 'Geist Mono', ui-monospace, monospace !important;
+        font-size: 12px !important;
+      }
+      .mermaid .sequenceNumber { fill: ${THEME.darkGreen} !important; }
+      .mermaid text.sequenceNumber { fill: #FFFFFF !important; }
+      .mermaid .note {
+        fill: ${THEME.greenBase} !important;
+        stroke: ${THEME.darkGreen} !important;
+        filter: drop-shadow(3px 3px 0 rgba(0,0,0,.08));
+      }
+      .mermaid .noteText, .mermaid .noteText > tspan {
+        fill: ${THEME.darkGreen} !important;
+        font-family: 'Geist Mono', ui-monospace, monospace !important;
+        font-size: 11px !important;
+      }
+      /* Activation rectangles = TAP cyan (authorization in flight). */
+      .mermaid rect.activation0, .mermaid rect.activation1, .mermaid rect.activation2 {
+        fill: ${THEME.cyanSoft} !important;
+        stroke: ${THEME.cyan} !important;
+        stroke-width: 1px !important;
+      }
+    `;
+    document.head.appendChild(s);
+  }
+
+  /* Convert Jekyll-rendered ```mermaid``` blocks
+     (`<pre><code class="language-mermaid">`) into `<div class="mermaid">`
+     containers so mermaid can render them. */
+  function convertCodeBlocks() {
+    document.querySelectorAll('pre code.language-mermaid').forEach(function (el) {
+      const div = document.createElement('div');
+      div.className = 'mermaid';
+      div.textContent = el.textContent;
+      const pre = el.parentElement;
+      pre.parentElement.replaceChild(div, pre);
+    });
+  }
+
+  /* Render an SVG string returned by mermaid into `el` without using innerHTML.
+     Parses the markup as XML and replaces children with the resulting <svg> node. */
+  function setSvg(el, svgMarkup) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgMarkup, 'image/svg+xml');
+    const svg = doc.documentElement;
+    if (svg && svg.nodeName.toLowerCase() === 'svg') {
+      el.replaceChildren(document.importNode(svg, true));
+    } else {
+      el.replaceChildren(document.createTextNode('[mermaid: invalid SVG]'));
+    }
+  }
+
+  async function runBlocks() {
+    const blocks = document.querySelectorAll('div.mermaid, pre.mermaid');
+    for (let i = 0; i < blocks.length; i++) {
+      const el = blocks[i];
+      if (el.dataset.processed === 'true') continue;
+      const source = (el.dataset.source || el.textContent).trim();
+      el.dataset.source = source;
+      const id = 'tap-mmd-' + i + '-' + Math.random().toString(36).slice(2, 8);
+      try {
+        const { svg, bindFunctions } = await window.mermaid.render(id, source);
+        setSvg(el, svg);
+        if (bindFunctions) bindFunctions(el);
+        el.dataset.processed = 'true';
+      } catch (e) {
+        console.error('[TapMermaid] render failed', e);
+        const pre = document.createElement('pre');
+        pre.style.cssText = 'color:#8A1B1B;font-family:monospace;font-size:11px';
+        pre.textContent = String(e.message || e);
+        el.replaceChildren(pre);
+      }
+    }
+  }
+
+  window.TapMermaid = {
+    config: cfg,
+    async init() {
+      if (!window.mermaid) {
+        console.warn('[TapMermaid] mermaid not loaded');
+        return;
+      }
+      injectStyles();
+      window.mermaid.initialize(cfg);
+      convertCodeBlocks();
+      await runBlocks();
+    },
+    rerun: runBlocks,
+  };
+
+  document.addEventListener('DOMContentLoaded', function () {
+    window.TapMermaid.init();
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -5,13 +5,18 @@ title: Home
 
 <div class="home-content">
   <header class="hero">
-    <h1>Transaction Authorization Protocol</h1>
-    <p class="lead">A framework for secure, compliant, and flexible blockchain transaction authorization</p>
+    <div class="tap-eyebrow">Transaction Authorization Protocol</div>
+    <h1>The open authorization layer for blockchain transactions.</h1>
+    <p class="lead">Identity, compliance, and multi-party authorization &mdash; before anything settles onchain.</p>
+    <div class="tap-chip">
+      <span class="tap-chip-dot"></span>
+      Open protocol &middot; CC BY-SA 4.0
+    </div>
   </header>
 
   <section class="intro">
-    <p>The Transaction Authorization Protocol (TAP) enables secure, compliant, and flexible transaction authorization between parties before settlement on a blockchain. TAP creates a separate "authorization layer" that operates independently from the blockchain "settlement layer," allowing participants to exchange necessary information, perform risk assessments, and implement compliance checks before funds move.</p>
-    
+    <p>The Transaction Authorization Protocol (TAP) enables secure, compliant, and flexible transaction authorization between parties before settlement on a blockchain. TAP creates a separate <strong>authorization layer</strong> that operates independently from the blockchain <strong>settlement layer</strong>, allowing participants to exchange necessary information, perform risk assessments, and implement compliance checks before funds move.</p>
+
     <div class="cta-buttons">
       <a href="https://hubs.ly/Q03FRgly0" class="button">Read the Whitepaper</a>
       <a href="{{ '/messages/' | relative_url }}" class="button button-secondary">View TAP Messages</a>
@@ -70,112 +75,162 @@ title: Home
 
 <style>
   .hero {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     padding-bottom: 1rem;
   }
-  
+
+  .hero .tap-eyebrow {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--tap-ink);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 1.25rem;
+  }
+
+  .hero .tap-eyebrow::before {
+    content: '';
+    display: inline-block;
+    width: 18px;
+    height: 2px;
+    background: var(--tap-accent);
+  }
+
   .hero h1 {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-    color: var(--color-text);
+    font-family: var(--font-heading);
+    font-size: 3rem;
+    font-weight: 400;
+    letter-spacing: -0.035em;
+    line-height: 1.05;
+    margin: 0 0 1.25rem;
+    color: var(--tap-ink);
+    max-width: 780px;
   }
-  
+
   .lead {
+    font-family: var(--font-sans);
     font-size: 1.25rem;
-    color: var(--color-text-light);
-    margin-bottom: 2rem;
+    line-height: 1.45;
+    letter-spacing: -0.02em;
+    color: var(--tap-ink-2);
+    margin-bottom: 1.5rem;
+    max-width: 680px;
   }
-  
+
+  .tap-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(0,47,13,.06);
+    color: var(--tap-ink);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .tap-chip-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--tap-accent);
+  }
+
   .cta-buttons {
     display: flex;
     gap: 1rem;
-    margin: 2rem 0;
+    margin: 2rem 0 2.5rem;
+    flex-wrap: wrap;
   }
-  
-  .button {
-    display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background-color: var(--color-primary);
-    color: var(--color-text);
-    border-radius: 0.375rem;
+
+  .intro, .taips-section { margin-bottom: 3rem; }
+
+  .taips-section h2 {
+    font-size: 1.75rem;
     font-weight: 500;
-    text-decoration: none;
-    transition: background-color 0.2s, transform 0.2s;
-    font-family: var(--font-heading);
+    letter-spacing: -0.03em;
   }
-  
-  .button:hover {
-    background-color: var(--color-primary-light);
-    text-decoration: none;
-    transform: translateY(-2px);
+
+  .taips-section h3 {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--tap-ink);
+    margin-top: 2.5rem;
+    margin-bottom: 1.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
   }
-  
-  .button-secondary {
-    background-color: var(--color-secondary-bg);
-    color: var(--color-secondary-fg);
-    border: 1px solid var(--color-primary);
+
+  .taips-section h3::before {
+    content: '';
+    display: inline-block;
+    width: 18px;
+    height: 2px;
+    background: var(--tap-accent);
   }
-  
-  .button-secondary:hover {
-    background-color: var(--color-secondary-bg);
-    opacity: 0.9;
-  }
-  
-  .intro, .taips-section {
-    margin-bottom: 3rem;
-  }
-  
+
   .taips-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1.5rem;
+    gap: 1.25rem;
+    margin-top: 1.25rem;
   }
-  
+
   .taip-card {
-    background-color: var(--color-sidebar);
-    border-radius: 0.5rem;
+    background: rgba(0,47,13,.02);
+    border: 1px solid var(--border-soft);
+    border-radius: 10px;
     padding: 1.5rem;
-    transition: transform 0.2s, box-shadow 0.2s;
-    border: 1px solid var(--color-border);
+    transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
-  
+
   .taip-card:hover {
     transform: translateY(-3px);
-    box-shadow: 0 4px 12px rgba(65, 224, 41, 0.1);
-    border-color: var(--color-primary);
+    border-color: var(--tap-accent);
+    box-shadow: 0 12px 24px -16px rgba(0,47,13,.18);
   }
-  
+
   .taip-card h4 {
-    margin-top: 0;
-    margin-bottom: 0.75rem;
-  }
-  
-  .taip-card h4 a {
-    color: var(--color-text);
-  }
-  
-  .taip-card h4 a:hover {
-    color: var(--color-primary);
-  }
-  
-  .more-link {
-    text-align: center;
-    margin-top: 2rem;
-  }
-  
-  .view-all {
-    display: inline-block;
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--color-border);
-    border-radius: 0.375rem;
-    font-weight: 500;
+    margin: 0 0 0.25rem;
     font-family: var(--font-heading);
-    transition: all 0.2s;
+    font-weight: 500;
+    font-size: 1.05rem;
+    letter-spacing: -0.02em;
+    line-height: 1.25;
   }
-  
-  .view-all:hover {
-    border-color: var(--color-primary);
-    background-color: var(--color-secondary-bg);
+
+  .taip-card h4 a {
+    color: var(--tap-ink);
+    text-decoration: none;
+  }
+
+  .taip-card h4 a:hover {
+    color: var(--tap-ink);
+    opacity: .75;
+    text-decoration: none;
+  }
+
+  .taip-card p {
+    margin: 0.25rem 0 0;
+    font-size: 0.9375rem;
+    color: var(--tap-ink-2);
+    line-height: 1.5;
+  }
+
+  .taip-card .status-pill {
+    align-self: flex-start;
   }
 </style>

--- a/messages.md
+++ b/messages.md
@@ -12,6 +12,8 @@ permalink: /messages/
 - [Transaction Message](#transaction-message)
   - [Transfer](#transfer)
   - [Payment](#payment)
+  - [RFQ](#rfq)
+  - [Quote](#quote)
   - [Lock](#lock)
 - [Authorization Flow Messages](#authorization-flow-messages)
   - [AuthorizationRequired](#authorizationrequired)


### PR DESCRIPTION
## Summary

Rebrands the Jekyll documentation site to the TAP visual identity (Notabene foundations + TAP cyan accent), per the `tap-branding` skill.

- **Visual tokens** — Dark forest green (`#002F0D`) ink on beige (`#FAF8F2`), TAP cyan (`#00C2B8`) as the authorization-signal accent, settlement green reserved for `#41E129`. Fonts: Roboto Slab + Inter + Geist Mono.
- **Logo** — Replaces the plain "TAP" text with the canonical TAP beads SVG mark (dark / cyan / dark squares + connector + cyan dot).
- **Hero** — Cyan-bar eyebrow, slab-serif headline, *"Open protocol · CC BY-SA 4.0"* provenance chip.
- **TAIP cards / metadata / ToC / status pills** — Restyled to the TAP card system; pills set in mono with semantic colors per status.
- **Mermaid diagrams** — Adds `assets/js/mermaid-theme.js` ported from the `notabene-branding` skill: dark green slab actors, mono edge labels, sharp 3px shadow, dashed lifelines, beige cluster framing. TAP twist: sequence-activation rectangles render in cyan ("authorization in flight"). Removes two competing inline mermaid init scripts.
- **`messages.md` ToC** — Adds missing **RFQ** and **Quote** entries (the body sections were already present from TAIP-18).
- **Build compat** — Adds `gem "logger"` / `csv` / `base64` so `bundle exec jekyll serve` works on Ruby 3.3+ (Jekyll 4.2 stdlib gap; pre-existing breakage on `main`).

Verified locally with `bundle exec jekyll serve` — home page, message reference, and several TAIP detail pages (4, 5, 14, 17, 18) render cleanly with rethemed mermaid diagrams.

## Test plan
- [ ] Pull the branch, `bundle install`, `bundle exec jekyll serve`, open <http://127.0.0.1:4000/> and confirm the TAP beads logo, hero eyebrow + chip, and TAIP card grid
- [ ] Visit `/messages/` and confirm RFQ + Quote appear in the Table of Contents
- [ ] Visit `/TAIPs/taip-4` and confirm sequence diagrams render with dark-green slab actors, mono edge labels, and the 3px sharp shadow
- [ ] Spot-check `/TAIPs/taip-15` and `/TAIPs/taip-17` for flowchart/state-diagram styling
- [ ] Confirm GitHub Pages deploy succeeds (or your usual deploy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)