### PR TITLE
Replace placeholder emoji favicon with TAP beads mark

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔄</text></svg>">
+  <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon.svg' | relative_url }}">
+  <link rel="apple-touch-icon" href="{{ '/assets/apple-touch-icon.svg' | relative_url }}">
+  <meta name="theme-color" content="#002F0D">
   <!-- Mermaid.js for diagrams -->
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script src="{{ '/assets/js/mermaid-theme.js' | relative_url }}" defer></script>

--- a/assets/apple-touch-icon.svg
+++ b/assets/apple-touch-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180">
+  <rect width="180" height="180" fill="#FAF8F2"/>
+  <rect x="22"  y="42" width="40" height="40" rx="4" fill="#002F0D"/>
+  <rect x="70"  y="42" width="40" height="40" rx="4" fill="#00C2B8"/>
+  <rect x="118" y="42" width="40" height="40" rx="4" fill="#002F0D"/>
+  <path d="M42 100 V134 H138 V100" stroke="#002F0D" stroke-width="11" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90" cy="134" r="14" fill="#00C2B8"/>
+</svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#FAF8F2"/>
+  <rect x="3"  y="6"  width="8" height="8" rx="1" fill="#002F0D"/>
+  <rect x="12" y="6"  width="8" height="8" rx="1" fill="#00C2B8"/>
+  <rect x="21" y="6"  width="8" height="8" rx="1" fill="#002F0D"/>
+  <path d="M7 18 V25 H25 V18" stroke="#002F0D" stroke-width="2.25" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="16" cy="25" r="3" fill="#00C2B8"/>
+</svg>


### PR DESCRIPTION
## Summary

The site was using a placeholder 🔄 emoji as its favicon. This swaps it for a proper SVG of the TAP beads wordmark — same composition as the in-page logo (dark-green / cyan / dark-green beads + cyan connector dot) — sized down for browser tabs and home-screen tiles.

- **`/assets/favicon.svg`** — 32×32 viewBox, beige rounded background, three 8px beads with the brand cyan in the middle, connector path + cyan dot below. Designed to stay legible at 16×16.
- **`/assets/apple-touch-icon.svg`** — 180×180 variant with chunkier strokes for iOS home-screen tiles.
- **`<meta name="theme-color" content="#002F0D">`** — paints the mobile browser chrome dark forest green to match.

## Test plan
- [ ] After deploy + hard refresh, browser tab shows the TAP beads mark instead of 🔄
- [ ] Pin to iOS home screen → tile shows the bigger 180px composition
- [ ] No 404s on `/assets/favicon.svg` or `/assets/apple-touch-icon.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)