### PR TITLE
Add llms.txt describing TAP and indexing every TAIP

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@
 title: Transaction Authorization Improvement Proposals
 description: >- # this means to ignore newlines until "baseurl:"
   Transaction Authorization Improvement Proposals (TAIPs) describe standards for off-chain authorizations of transactions between multiple parties.
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://taips.tap.rsvp"
 github_username: TransactionAuthorizationProtocol
 repository: TransactionAuthorizationProtocol/TAIPs
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,79 @@
+---
+layout: null
+permalink: /llms.txt
+sitemap: false
+---
+# TAP — Transaction Authorization Protocol
+
+> The Transaction Authorization Protocol (TAP) is an open, chain-agnostic messaging layer that adds identity, compliance, and multi-party authorization to blockchain transactions before they settle. TAP creates a separate authorization layer that operates independently from the blockchain settlement layer, allowing participants to exchange the necessary information, perform risk assessments, and implement compliance checks before funds move. TAP is donated by Notabene and is licensed CC BY-SA 4.0; the canonical source for every standard is the set of Transaction Authorization Improvement Proposals (TAIPs) listed below.
+
+Key concepts:
+
+- **Agents** — software acting on behalf of participants (VASPs, wallets, custodians, payment processors, AI agents) that exchange TAP messages.
+- **Parties** — the real-world legal or natural persons whose transaction is being authorized.
+- **Transaction message types** — Transfer (push), Payment (pull/merchant), RFQ + Quote (asset swap / FX), Lock + Capture (escrow).
+- **Authorization flow** — AuthorizationRequired, Authorize, Settle, Reject, Cancel, Revert.
+- **Identity & compliance** — IVMS101 Travel Rule data, LEI for institutions, hashed party names, ISO 20022 purpose codes, selective disclosure via W3C Verifiable Credentials.
+- **Transport** — DIDComm v2 over HTTPS, JSON-LD bodies, JWS signatures with optional JWE encryption.
+
+## Core resources
+
+- [TAP overview]({{ '/overview/' | absolute_url }}): high-level concepts, motivation, and how the authorization and settlement layers interact.
+- [TAP message reference]({{ '/messages/' | absolute_url }}): every message type, field, and a worked example.
+- [Transaction types]({{ '/transactions/' | absolute_url }}): business-level overview of Transfer, Payment, RFQ, and Lock.
+- [Authorization flow]({{ '/authorization/' | absolute_url }}): how Authorize / Settle / Reject / Cancel / Revert thread together.
+- [Parties]({{ '/parties/' | absolute_url }}) and [Agents]({{ '/agents/' | absolute_url }}): identity model used across all TAP messages.
+- [Developer resources]({{ '/developers/' | absolute_url }}): SDK pointers, JSON Schemas, test vectors.
+- [Changelog]({{ '/changelog/' | absolute_url }}): structural changes across TAIPs.
+- [JSON Schemas](https://github.com/TransactionAuthorizationProtocol/TAIPs/tree/main/schemas): JSON Schema 2020-12 definitions for every message and shared structure.
+- [Test vectors](https://github.com/TransactionAuthorizationProtocol/TAIPs/tree/main/test-vectors): valid + invalid examples for protocol implementers.
+- [TypeScript SDK (`@taprsvp/types`)](https://github.com/TransactionAuthorizationProtocol/tap-ts): published types for TAP messages.
+
+## TAIPs
+
+Every TAIP below links to the raw Markdown source on GitHub.
+
+{%- assign source_base = "https://raw.githubusercontent.com/TransactionAuthorizationProtocol/TAIPs/main/TAIPs" -%}
+{%- assign all_taips = site.pages | where_exp: "p", "p.path contains 'TAIPs/taip-'" | sort: "taip" -%}
+
+{%- assign final_taips = all_taips | where: "status", "Final" -%}
+{%- if final_taips.size > 0 %}
+### Final
+
+{% for t in final_taips -%}
+- [TAIP-{{ t.taip }}: {{ t.title }}]({{ source_base }}/taip-{{ t.taip }}.md){% if t.description %}: {{ t.description | strip_newlines }}{% endif %}
+{% endfor %}
+{%- endif %}
+
+{%- assign lastcall_taips = all_taips | where: "status", "Last Call" -%}
+{%- if lastcall_taips.size > 0 %}
+### Last Call
+
+{% for t in lastcall_taips -%}
+- [TAIP-{{ t.taip }}: {{ t.title }}]({{ source_base }}/taip-{{ t.taip }}.md){% if t.description %}: {{ t.description | strip_newlines }}{% endif %}
+{% endfor %}
+{%- endif %}
+
+{%- assign review_taips = all_taips | where: "status", "Review" -%}
+{%- if review_taips.size > 0 %}
+### Review
+
+{% for t in review_taips -%}
+- [TAIP-{{ t.taip }}: {{ t.title }}]({{ source_base }}/taip-{{ t.taip }}.md){% if t.description %}: {{ t.description | strip_newlines }}{% endif %}
+{% endfor %}
+{%- endif %}
+
+{%- assign draft_taips = all_taips | where: "status", "Draft" -%}
+{%- if draft_taips.size > 0 %}
+### Draft
+
+{% for t in draft_taips -%}
+- [TAIP-{{ t.taip }}: {{ t.title }}]({{ source_base }}/taip-{{ t.taip }}.md){% if t.description %}: {{ t.description | strip_newlines }}{% endif %}
+{% endfor %}
+{%- endif %}
+
+## Optional
+
+- [Site source on GitHub](https://github.com/TransactionAuthorizationProtocol/TAIPs): the canonical repository for all TAIPs and this site.
+- [Contributing guidelines](https://github.com/TransactionAuthorizationProtocol/TAIPs/blob/main/CONTRIBUTING.md): how to propose a new TAIP or revise an existing one.
+- [TAP marketing site](https://tap.rsvp): high-level introduction and use-case explainers.


### PR DESCRIPTION
## Summary

Adds an [`llms.txt`](https://llmstxt.org/) at the site root so LLM tooling can discover what TAP is and pull each TAIP's authoritative Markdown source directly.

The file is rendered by Jekyll/Liquid from each TAIP's frontmatter, so it stays current automatically as new TAIPs are added or status fields change.

**Structure**

- **H1 + summary** — what TAP is in one paragraph, plus a "Key concepts" list (agents, parties, transaction message types, authorization flow, identity/compliance, transport).
- **Core resources** — links to overview, message reference, transaction types, authorization flow, parties, agents, developer resources, JSON Schemas, test vectors, and the TypeScript SDK.
- **TAIPs** — every TAIP grouped by status (Final / Last Call / Review / Draft), each with its description from frontmatter and a link to the raw Markdown source on GitHub.
- **Optional** — pointers to the GitHub repo, contributing guide, and tap.rsvp marketing site.

**Also in this PR**

- Sets `site.url: "https://taips.tap.rsvp"` in `_config.yml` so `absolute_url` produces correct production URLs in `llms.txt` and the existing JSON feed (was previously empty, defaulting to whatever Jekyll picked).

## Test plan
- [ ] After deploy, fetch `https://taips.tap.rsvp/llms.txt` and confirm it returns plain Markdown (Content-Type text/plain) with all 20 TAIPs grouped by status
- [ ] Spot-check a few raw markdown links resolve, e.g. `https://raw.githubusercontent.com/TransactionAuthorizationProtocol/TAIPs/main/TAIPs/taip-3.md`
- [ ] Confirm absolute URLs in JSON feed (`/feed.xml`) point to `https://taips.tap.rsvp/...`
- [ ] When a new TAIP lands or its status flips, regenerate the build and verify llms.txt updates without further code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)