### PR TITLE
Add HubSpot tracking script to all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -135,5 +135,8 @@
     });
   </script>
 
+  <!-- Start of HubSpot Embed Code -->
+  <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/7222759.js"></script>
+  <!-- End of HubSpot Embed Code -->
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds the HubSpot embed script (account `7222759`) immediately before the closing `</body>` tag of the default layout. Since `page.html` and `taip.html` both inherit from `default`, the script runs on every rendered page (home, overview, message reference, developer resources, transactions, parties, agents, and every TAIP detail page).

```html
<!-- Start of HubSpot Embed Code -->
<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/7222759.js"></script>
<!-- End of HubSpot Embed Code -->
```

## Test plan
- [ ] After deploy, view source on any page and confirm the embed script appears just before `</body>`
- [ ] Confirm the script loads (DevTools → Network → `hs-scripts.com`)
- [ ] Confirm pageview events register in HubSpot for taips.tap.rsvp

🤖 Generated with [Claude Code](https://claude.com/claude-code)