### PR TITLE
Remove stale Google Analytics tag G-LR9HTF1W99

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,21 +25,6 @@
     }
   </style>
   {%- feed_meta -%}
-  
+
   <!-- Mermaid is initialized via /assets/js/mermaid-theme.js (loaded by the default layout). -->
-
-
-  {%- if jekyll.environment == 'production' -%}
-    <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LR9HTF1W99"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-LR9HTF1W99');
-  </script>
-  {%- endif -%}
-
-
 </head>


### PR DESCRIPTION
## Summary

Removes the unused `G-LR9HTF1W99` GA tag from `_includes/head.html`. That include is never pulled into any layout (the default layout has its own inline `<head>`), so the tag never reached rendered pages. The active analytics property `G-DFQHXTJQ91` in `_layouts/default.html` is unaffected.

## Test plan
- [ ] After deploy, view source on any page and confirm `G-DFQHXTJQ91` still loads
- [ ] Confirm `G-LR9HTF1W99` no longer appears anywhere in built HTML
- [ ] Confirm pageview events keep arriving in the GA property for `G-DFQHXTJQ91`

🤖 Generated with [Claude Code](https://claude.com/claude-code)